### PR TITLE
Enhance telemetry setup with error handling and performance improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -142,7 +142,7 @@
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.4.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
+    <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Enrichers.Sensitive" Version="1.7.3" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />

--- a/framework/src/BBT.Aether.AspNetCore/BBT.Aether.AspNetCore.csproj
+++ b/framework/src/BBT.Aether.AspNetCore/BBT.Aether.AspNetCore.csproj
@@ -37,6 +37,7 @@
         <PackageReference Include="Serilog.Formatting.Compact"/>
         <PackageReference Include="Serilog.Sinks.Console"/>
         <PackageReference Include="Serilog.Sinks.File"/>
+        <PackageReference Include="Serilog.Sinks.OpenTelemetry"/>
         <PackageReference Include="Microsoft.Extensions.Diagnostics"/>
         <PackageReference Include="Microsoft.AspNetCore.ResponseCompression"/>
         <ProjectReference Include="..\BBT.Aether.Application\BBT.Aether.Application.csproj"/>

--- a/framework/src/BBT.Aether.AspNetCore/Microsoft/Extensions/DependencyInjection/AetherTelemetryServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.AspNetCore/Microsoft/Extensions/DependencyInjection/AetherTelemetryServiceCollectionExtensions.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using BBT.Aether.AspNetCore.Telemetry;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -18,35 +23,83 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class AetherTelemetryServiceCollectionExtensions
 {
+    // Performance: Cache compiled regex patterns
+    private static readonly ConcurrentDictionary<string, Regex> RegexCache = new();
+    
+    // Performance: Cache base64 encoded credentials
+    private static readonly ConcurrentDictionary<string, string> AuthHeaderCache = new();
     public static IServiceCollection AddFrameworkTelemetry(
         this IServiceCollection services,
         IConfiguration configuration,
         Action<LoggerConfiguration, TelemetryOptions>? configureLogger = null)
     {
-        var options = configuration.GetSection("Telemetry").Get<TelemetryOptions>() ?? new TelemetryOptions();
-        ConfigureOptions(options, configuration);
-        ConfigureTraceProvider(services, options);
-        ConfigureLogProvider(services, options, configureLogger);
+        try
+        {
+            var options = configuration.GetSection("Telemetry").Get<TelemetryOptions>() ?? new TelemetryOptions();
+            ConfigureOptions(options, configuration);
+            ConfigureTraceProvider(services, options);
+            ConfigureLogProvider(services, options, configureLogger);
 
-        return services;
+            return services;
+        }
+        catch (Exception ex)
+        {
+            // Log error but don't fail application startup
+            try
+            {
+                using var serviceProvider = services.BuildServiceProvider();
+                var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
+                var logger = loggerFactory?.CreateLogger("AetherTelemetry");
+                logger?.LogError(ex, "Failed to configure telemetry. Continuing without telemetry.");
+            }
+            catch
+            {
+                // Even logging failed, but don't crash the application
+            }
+            return services;
+        }
     }
 
     private static void ConfigureOptions(TelemetryOptions options, IConfiguration configuration)
     {
-        if (options.Environment.IsNullOrWhiteSpace())
+        try
         {
-            options.Environment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Development";
-        }
+            if (options.Environment.IsNullOrWhiteSpace())
+            {
+                options.Environment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Development";
+            }
 
-        if (options.ServiceName.IsNullOrWhiteSpace())
-        {
-            options.ServiceName = configuration["OTEL_SERVICE_NAME"] ?? configuration["ApplicationName"];
-        }
+            if (options.ServiceName.IsNullOrWhiteSpace())
+            {
+                options.ServiceName = configuration["OTEL_SERVICE_NAME"] ?? configuration["ApplicationName"] ?? "Unknown";
+            }
 
-        if (options.ServiceVersion.IsNullOrWhiteSpace())
+            if (options.ServiceVersion.IsNullOrWhiteSpace())
+            {
+                try
+                {
+                    var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+                    if (!string.IsNullOrEmpty(assemblyLocation))
+                    {
+                        options.ServiceVersion = FileVersionInfo.GetVersionInfo(assemblyLocation).FileVersion ?? "1.0.0";
+                    }
+                    else
+                    {
+                        options.ServiceVersion = "1.0.0";
+                    }
+                }
+                catch
+                {
+                    options.ServiceVersion = "1.0.0";
+                }
+            }
+        }
+        catch
         {
-            var assemblyLocation = Assembly.GetExecutingAssembly().Location;
-            options.ServiceVersion = FileVersionInfo.GetVersionInfo(assemblyLocation).FileVersion ?? "1.0.0";
+            // Ensure we have safe defaults
+            options.Environment ??= "Development";
+            options.ServiceName ??= "Unknown";
+            options.ServiceVersion ??= "1.0.0";
         }
     }
 
@@ -74,34 +127,78 @@ public static class AetherTelemetryServiceCollectionExtensions
                     {
                         b.EnrichWithHttpResponse = (activity, httpResponse) =>
                         {
-                            var headersToLog = options.Logging?.Enrichers?.Headers ?? [];
-                            activity.DisplayName =
-                                $"{httpResponse.HttpContext.Request.Method} {httpResponse.HttpContext.Request.Path.Value ?? "unknown"}";
-                            activity.SetTag("http.route", httpResponse.HttpContext.Request.Path.Value ?? "unknown");
-                            foreach (var header in headersToLog)
+                            try
                             {
-                                activity.SetTag($"http.request.header.{header.ToLower()}",
-                                    httpResponse.HttpContext.Request.Headers.TryGetValue(header, out var headerValue)
-                                        ? headerValue.ToString()
-                                        : "-");
+                                var headersToLog = options.Logging?.Enrichers?.Headers ?? [];
+                                var httpMethod = httpResponse.HttpContext.Request.Method;
+                                
+                                // Get route pattern for better transaction grouping (with error handling)
+                                var routePattern = GetRoutePatternSafe(httpResponse.HttpContext);
+                                
+                                activity.DisplayName = $"{httpMethod} {routePattern}";
+                                activity.SetTag("http.route", routePattern);
+                                
+                                // Performance: Avoid allocation if no headers to log
+                                if (headersToLog.Count > 0)
+                                {
+                                    foreach (var header in headersToLog)
+                                    {
+                                        try
+                                        {
+                                            var headerKey = $"http.request.header.{header.ToLowerInvariant()}";
+                                            var headerValue = httpResponse.HttpContext.Request.Headers.TryGetValue(header, out var value)
+                                                ? value.ToString()
+                                                : "-";
+                                            activity.SetTag(headerKey, headerValue);
+                                        }
+                                        catch
+                                        {
+                                            // Skip problematic headers
+                                        }
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                                // Don't break telemetry for header processing errors
                             }
                         };
 
                         b.Filter = httpContext =>
                         {
-                            var path = httpContext.Request.Path.Value;
-
-                            if (path == null) return true;
-
-                            foreach (var pattern in options.Logging.ExcludedPaths)
+                            try
                             {
-                                if (Regex.IsMatch(path, pattern, RegexOptions.IgnoreCase))
-                                {
-                                    return false;
-                                }
-                            }
+                                var path = httpContext.Request.Path.Value;
+                                if (string.IsNullOrEmpty(path)) return true;
 
-                            return true;
+                                var excludedPaths = options.Logging?.ExcludedPaths;
+                                if (excludedPaths == null || excludedPaths.Count == 0) return true;
+
+                                // Performance: Use cached compiled regex
+                                foreach (var pattern in excludedPaths)
+                                {
+                                    try
+                                    {
+                                        var regex = RegexCache.GetOrAdd(pattern, p => new Regex(p, RegexOptions.IgnoreCase | RegexOptions.Compiled));
+                                        if (regex.IsMatch(path))
+                                        {
+                                            return false;
+                                        }
+                                    }
+                                    catch
+                                    {
+                                        // Skip invalid regex patterns
+                                        continue;
+                                    }
+                                }
+
+                                return true;
+                            }
+                            catch
+                            {
+                                // Default to including the request if filtering fails
+                                return true;
+                            }
                         };
                     })
                     .AddEntityFrameworkCoreInstrumentation(efOptions =>
@@ -122,19 +219,42 @@ public static class AetherTelemetryServiceCollectionExtensions
 
     private static TracerProviderBuilder AddTraceExporter(this TracerProviderBuilder builder, TelemetryOptions options)
     {
-        if (options.TraceProvider?.ToLower() == "zipkin")
+        try
         {
-            builder.AddZipkinExporter(zipkinOptions =>
+            var provider = options.TraceProvider?.ToLowerInvariant();
+            
+            switch (provider)
             {
-                zipkinOptions.Endpoint = new Uri(options.Zipkin.Endpoint);
-            });
+                case "zipkin":
+                    if (!string.IsNullOrEmpty(options.Zipkin?.Endpoint))
+                    {
+                        builder.AddZipkinExporter(zipkinOptions =>
+                        {
+                            if (Uri.TryCreate(options.Zipkin.Endpoint, UriKind.Absolute, out var uri))
+                            {
+                                zipkinOptions.Endpoint = uri;
+                            }
+                        });
+                    }
+                    break;
+                    
+                case "otlp":
+                    if (!string.IsNullOrEmpty(options.Otlp?.Endpoint))
+                    {
+                        builder.AddOtlpExporter(otlpOptions =>
+                        {
+                            if (Uri.TryCreate(options.Otlp.Endpoint, UriKind.Absolute, out var uri))
+                            {
+                                otlpOptions.Endpoint = uri;
+                            }
+                        });
+                    }
+                    break;
+            }
         }
-        else if (options.TraceProvider?.ToLower() == "otlp")
+        catch
         {
-            builder.AddOtlpExporter(otlpOptions =>
-            {
-                otlpOptions.Endpoint = new Uri(options.Otlp.Endpoint);
-            });
+            // Continue without trace exporter if configuration fails
         }
 
         return builder;
@@ -142,37 +262,63 @@ public static class AetherTelemetryServiceCollectionExtensions
 
     private static MeterProviderBuilder AddMetricExporter(this MeterProviderBuilder builder, TelemetryOptions options)
     {
-        switch (options.TraceProvider.ToLower())
+        var provider = options.TraceProvider;
+        
+        switch (provider?.ToLower())
         {
             case "otlp":
-                builder.AddOtlpExporter(otlpOptions =>
-                {
-                    otlpOptions.Endpoint = new Uri(options.Otlp.Endpoint);
-                });
-                break;
-
             case "elastic":
+            case "openobserve":
+                // All these providers use OTLP protocol
+                // Configuration can be done via environment variables (OTEL_EXPORTER_OTLP_METRICS_*)
+                // or via code configuration below
                 builder.AddOtlpExporter(otlpOptions =>
                 {
-                    otlpOptions.Endpoint = new Uri(options.Elastic.Endpoint);
-                    if (!string.IsNullOrEmpty(options.Elastic.Username))
+                    // Only set if not already configured via environment variables
+                    if (otlpOptions.Endpoint == null)
                     {
-                        otlpOptions.Headers =
-                            $"Authorization=Bearer {Convert.ToBase64String(Encoding.UTF8.GetBytes($"{options.Elastic.Username}:{options.Elastic.Password}"))}";
+                        var endpoint = provider switch
+                        {
+                            "otlp" => options.Otlp?.Endpoint,
+                            "elastic" => options.Elastic?.Endpoint,
+                            "openobserve" => options.OpenObserve?.Endpoint,
+                            _ => null
+                        };
+                        
+                        if (!string.IsNullOrEmpty(endpoint))
+                        {
+                            otlpOptions.Endpoint = new Uri(endpoint);
+                        }
+                    }
+                    
+                    // Set default protocol if not configured via env vars
+                    if (otlpOptions.Protocol == OpenTelemetry.Exporter.OtlpExportProtocol.Grpc)
+                    {
+                        otlpOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+                    }
+                    
+                    // Set auth headers if not configured via env vars and credentials available
+                    if (string.IsNullOrEmpty(otlpOptions.Headers))
+                    {
+                        var authHeader = provider switch
+                        {
+                            "elastic" when !string.IsNullOrEmpty(options.Elastic?.Username) =>
+                                GetCachedAuthHeader($"elastic:{options.Elastic.Username}:{options.Elastic.Password}"),
+                            "openobserve" when !string.IsNullOrEmpty(options.OpenObserve?.Username) =>
+                                GetCachedAuthHeader($"openobserve:{options.OpenObserve.Username}:{options.OpenObserve.Password}"),
+                            _ => null
+                        };
+                        
+                        if (!string.IsNullOrEmpty(authHeader))
+                        {
+                            otlpOptions.Headers = authHeader;
+                        }
                     }
                 });
                 break;
-
-            case "openobserve":
-                builder.AddOtlpExporter(otlpOptions =>
-                {
-                    otlpOptions.Endpoint = new Uri(options.OpenObserve.Endpoint);
-                    if (!string.IsNullOrEmpty(options.OpenObserve.Username))
-                    {
-                        otlpOptions.Headers =
-                            $"Authorization=Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes($"{options.OpenObserve.Username}:{options.OpenObserve.Password}"))}";
-                    }
-                });
+                
+            default:
+                // No metric exporter configured
                 break;
         }
 
@@ -194,19 +340,30 @@ public static class AetherTelemetryServiceCollectionExtensions
             .Enrich.WithProperty("DeploymentId", GetDeploymentId(options))
             .Filter.ByExcluding(Matching.FromSource("Microsoft.AspNetCore.StaticFiles"));
 
-        // Configure file logging
-        loggerConfig.WriteTo.File(
-            path: options.Logging.FilePath,
-            rollingInterval: RollingInterval.Day,
-            retainedFileCountLimit: 10,
-            rollOnFileSizeLimit: true,
-            outputTemplate:
-            "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+        if (options.LogProvider.Contains("file", StringComparison.OrdinalIgnoreCase))
+        {
+            // Configure file logging
+            loggerConfig.WriteTo.File(
+                path: options.Logging.FilePath,
+                rollingInterval: RollingInterval.Day,
+                retainedFileCountLimit: 10,
+                rollOnFileSizeLimit: true,
+                outputTemplate:
+                "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+        }
 
-        // Configure console logging
-        loggerConfig.WriteTo.Console(outputTemplate:
-            "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+        if (options.LogProvider.Contains("console", StringComparison.OrdinalIgnoreCase))
+        {
+            // Configure console logging
+            loggerConfig.WriteTo.Console(outputTemplate:
+                "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+        }
 
+        if (options.LogProvider.Contains("otlp", StringComparison.OrdinalIgnoreCase))
+        {
+            loggerConfig.WriteTo.OpenTelemetry();
+        }
+        
         configureLogger?.Invoke(loggerConfig, options);
 
         Log.Logger = loggerConfig.CreateLogger();
@@ -229,6 +386,44 @@ public static class AetherTelemetryServiceCollectionExtensions
         _ => LogEventLevel.Information
     };
 
-    public static string GetDeploymentId(TelemetryOptions options) =>
-        $"{options.Environment}-{options.ServiceName}-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString("N").Substring(0, 8)}";
+    private static string GetRoutePatternSafe(HttpContext httpContext)
+    {
+        try
+        {
+            var routePattern = (httpContext.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
+            return routePattern ?? httpContext.Request.Path.Value ?? "unknown";
+        }
+        catch
+        {
+            return httpContext.Request.Path.Value ?? "unknown";
+        }
+    }
+    
+    private static string GetCachedAuthHeader(string key)
+    {
+        return AuthHeaderCache.GetOrAdd(key, k =>
+        {
+            try
+            {
+                var parts = k.Split(':');
+                if (parts.Length >= 3)
+                {
+                    var username = parts[1];
+                    var password = parts[2];
+                    var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+                    return $"Authorization=Basic {credentials}";
+                }
+            }
+            catch
+            {
+                // Return empty if encoding fails
+            }
+            return string.Empty;
+        });
+    }
+
+    public static string GetDeploymentId(TelemetryOptions options)
+    {
+        return $"{options.Environment}-{options.ServiceName}-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString("N")[..8]}";
+    }
 }


### PR DESCRIPTION
Adds error handling to telemetry configuration to prevent startup failures, introduces caching for regex and auth headers, and improves route pattern extraction for better trace grouping. Updates metric and trace exporter configuration for flexibility and robustness. Also adds Serilog.Sinks.OpenTelemetry as a dependency and updates its version.

## Summary by Sourcery

Enhance the telemetry service registration to prevent startup failures, improve performance through caching, enrich HTTP spans more accurately, and make exporter and logging configurations more flexible and resilient.

Enhancements:
- Wrap telemetry setup in a try-catch to log errors without failing application startup
- Cache compiled regex patterns and base64-encoded auth headers to reduce overhead in telemetry enrichment
- Add safe defaults and error handling when resolving environment, service name, and service version
- Extract and enrich HTTP traces with route patterns and headers more reliably, with filtering based on cached regex
- Refactor trace and metric exporter setup to support Zipkin, OTLP, Elastic, and OpenObserve with safe URI parsing and flexible authentication
- Allow conditional Serilog sinks for file, console, and OTLP logging, and add Serilog.Sinks.OpenTelemetry as a dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added OTLP and Zipkin trace export options with safer defaults and error handling.
  - Introduced flexible metric exporters (Elastic, OpenObserve, OTLP) with optional auth header support.
  - Enabled OTLP logging alongside existing providers.
  - Enhanced HTTP telemetry: route pattern tagging, clearer operation names, and selective header logging.
  - More resilient startup with graceful fallback when telemetry setup fails.

- Chores
  - Updated Serilog.Sinks.OpenTelemetry to 4.2.0.
  - Added Serilog OpenTelemetry sink package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->