### PR TITLE
15 support local domain events

### DIFF
--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/Enrichers/HeaderLogEnricher.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/Enrichers/HeaderLogEnricher.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Tracing/AetherCorrelationIdMiddleware.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Tracing/AetherCorrelationIdMiddleware.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using BBT.Aether.Tracing;
@@ -26,15 +27,14 @@ public sealed class AetherCorrelationIdMiddleware(
 
     private string? GetCorrelationIdFromRequest(HttpContext context)
     {
-        var correlationId = context.Request.Headers[_options.HttpHeaderName];
-        if (correlationId.IsNullOrEmpty())
+        var correlationId = context.Request.Headers[_options.HttpHeaderName].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(correlationId))
         {
-            if (context.TraceIdentifier != null)
+            if (!string.IsNullOrWhiteSpace(context.TraceIdentifier))
             {
                 correlationId = context.TraceIdentifier;
             }
-
-            if (correlationId.IsNullOrEmpty())
+            else
             {
                 correlationId = Guid.NewGuid().ToString("N");
             }

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BasicAggregateRoot.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BasicAggregateRoot.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using BBT.Aether.Domain.Events;
+using BBT.Aether.Domain.Events.Distributed;
 
 namespace BBT.Aether.Domain.Entities;
 
@@ -13,6 +14,8 @@ public abstract class BasicAggregateRoot : Entity,
     IAggregateRoot
 {
     private readonly List<IDomainEvent> _domainEvents = new();
+    private readonly List<IDistributedDomainEvent> _distributedEvents = new();
+    private long _version = 0;
 
     /// <summary>
     /// Gets the domain events that have been raised by this aggregate root.
@@ -20,7 +23,17 @@ public abstract class BasicAggregateRoot : Entity,
     public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
     /// <summary>
-    /// Raises a domain event.
+    /// Gets the distributed domain events that have been raised by this aggregate root.
+    /// </summary>
+    public IReadOnlyCollection<IDistributedDomainEvent> DistributedEvents => _distributedEvents.AsReadOnly();
+
+    /// <summary>
+    /// Gets the current version of this aggregate root.
+    /// </summary>
+    public long EventVersion => _version;
+
+    /// <summary>
+    /// Raises a local domain event.
     /// </summary>
     /// <param name="domainEvent">The domain event to raise.</param>
     protected void Raise(IDomainEvent domainEvent)
@@ -32,11 +45,41 @@ public abstract class BasicAggregateRoot : Entity,
     }
 
     /// <summary>
+    /// Raises a distributed domain event.
+    /// </summary>
+    /// <param name="distributedEvent">The distributed domain event to raise.</param>
+    protected void RaiseDistributed(IDistributedDomainEvent distributedEvent)
+    {
+        if (distributedEvent == null)
+            throw new ArgumentNullException(nameof(distributedEvent));
+
+        _distributedEvents.Add(distributedEvent);
+        _version++; // Increment version for each distributed event
+    }
+
+    /// <summary>
     /// Clears all domain events from this aggregate root.
     /// </summary>
     public void ClearDomainEvents()
     {
         _domainEvents.Clear();
+    }
+
+    /// <summary>
+    /// Clears all distributed events from this aggregate root.
+    /// </summary>
+    public void ClearDistributedEvents()
+    {
+        _distributedEvents.Clear();
+    }
+
+    /// <summary>
+    /// Clears all events (both local and distributed) from this aggregate root.
+    /// </summary>
+    public void ClearAllEvents()
+    {
+        _domainEvents.Clear();
+        _distributedEvents.Clear();
     }
 }
 
@@ -49,11 +92,23 @@ public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     IAggregateRoot<TKey>
 {
     private readonly List<IDomainEvent> _domainEvents = new();
+    private readonly List<IDistributedDomainEvent> _distributedEvents = new();
+    private long _version = 0;
 
     /// <summary>
     /// Gets the domain events that have been raised by this aggregate root.
     /// </summary>
     public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    /// <summary>
+    /// Gets the distributed domain events that have been raised by this aggregate root.
+    /// </summary>
+    public IReadOnlyCollection<IDistributedDomainEvent> DistributedEvents => _distributedEvents.AsReadOnly();
+
+    /// <summary>
+    /// Gets the current version of this aggregate root.
+    /// </summary>
+    public long EventVersion => _version;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BasicAggregateRoot{TKey}"/> class.
@@ -72,7 +127,7 @@ public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     }
 
     /// <summary>
-    /// Raises a domain event.
+    /// Raises a local domain event.
     /// </summary>
     /// <param name="domainEvent">The domain event to raise.</param>
     protected void Raise(IDomainEvent domainEvent)
@@ -84,10 +139,40 @@ public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     }
 
     /// <summary>
+    /// Raises a distributed domain event.
+    /// </summary>
+    /// <param name="distributedEvent">The distributed domain event to raise.</param>
+    protected void RaiseDistributed(IDistributedDomainEvent distributedEvent)
+    {
+        if (distributedEvent == null)
+            throw new ArgumentNullException(nameof(distributedEvent));
+
+        _distributedEvents.Add(distributedEvent);
+        _version++; // Increment version for each distributed event
+    }
+
+    /// <summary>
     /// Clears all domain events from this aggregate root.
     /// </summary>
     public void ClearDomainEvents()
     {
         _domainEvents.Clear();
+    }
+
+    /// <summary>
+    /// Clears all distributed events from this aggregate root.
+    /// </summary>
+    public void ClearDistributedEvents()
+    {
+        _distributedEvents.Clear();
+    }
+
+    /// <summary>
+    /// Clears all events (both local and distributed) from this aggregate root.
+    /// </summary>
+    public void ClearAllEvents()
+    {
+        _domainEvents.Clear();
+        _distributedEvents.Clear();
     }
 }

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BasicAggregateRoot.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BasicAggregateRoot.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using BBT.Aether.Domain.Events;
 
 namespace BBT.Aether.Domain.Entities;
 
@@ -9,6 +12,32 @@ namespace BBT.Aether.Domain.Entities;
 public abstract class BasicAggregateRoot : Entity,
     IAggregateRoot
 {
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    /// <summary>
+    /// Gets the domain events that have been raised by this aggregate root.
+    /// </summary>
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    /// <summary>
+    /// Raises a domain event.
+    /// </summary>
+    /// <param name="domainEvent">The domain event to raise.</param>
+    protected void Raise(IDomainEvent domainEvent)
+    {
+        if (domainEvent == null)
+            throw new ArgumentNullException(nameof(domainEvent));
+
+        _domainEvents.Add(domainEvent);
+    }
+
+    /// <summary>
+    /// Clears all domain events from this aggregate root.
+    /// </summary>
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
 }
 
 /// <summary>
@@ -19,6 +48,13 @@ public abstract class BasicAggregateRoot : Entity,
 public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     IAggregateRoot<TKey>
 {
+    private readonly List<IDomainEvent> _domainEvents = new();
+
+    /// <summary>
+    /// Gets the domain events that have been raised by this aggregate root.
+    /// </summary>
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BasicAggregateRoot{TKey}"/> class.
     /// </summary>
@@ -33,5 +69,25 @@ public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     protected BasicAggregateRoot(TKey id)
         : base(id)
     {
+    }
+
+    /// <summary>
+    /// Raises a domain event.
+    /// </summary>
+    /// <param name="domainEvent">The domain event to raise.</param>
+    protected void Raise(IDomainEvent domainEvent)
+    {
+        if (domainEvent == null)
+            throw new ArgumentNullException(nameof(domainEvent));
+
+        _domainEvents.Add(domainEvent);
+    }
+
+    /// <summary>
+    /// Clears all domain events from this aggregate root.
+    /// </summary>
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
     }
 }

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BasicAggregateRoot.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BasicAggregateRoot.cs
@@ -38,8 +38,7 @@ public abstract class BasicAggregateRoot : Entity,
     /// <param name="domainEvent">The domain event to raise.</param>
     protected void Raise(IDomainEvent domainEvent)
     {
-        if (domainEvent == null)
-            throw new ArgumentNullException(nameof(domainEvent));
+        ArgumentNullException.ThrowIfNull(domainEvent);
 
         _domainEvents.Add(domainEvent);
     }
@@ -50,8 +49,7 @@ public abstract class BasicAggregateRoot : Entity,
     /// <param name="distributedEvent">The distributed domain event to raise.</param>
     protected void RaiseDistributed(IDistributedDomainEvent distributedEvent)
     {
-        if (distributedEvent == null)
-            throw new ArgumentNullException(nameof(distributedEvent));
+        ArgumentNullException.ThrowIfNull(distributedEvent);
 
         _distributedEvents.Add(distributedEvent);
         _version++; // Increment version for each distributed event
@@ -132,8 +130,7 @@ public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     /// <param name="domainEvent">The domain event to raise.</param>
     protected void Raise(IDomainEvent domainEvent)
     {
-        if (domainEvent == null)
-            throw new ArgumentNullException(nameof(domainEvent));
+        ArgumentNullException.ThrowIfNull(domainEvent);
 
         _domainEvents.Add(domainEvent);
     }
@@ -144,8 +141,7 @@ public abstract class BasicAggregateRoot<TKey> : Entity<TKey>,
     /// <param name="distributedEvent">The distributed domain event to raise.</param>
     protected void RaiseDistributed(IDistributedDomainEvent distributedEvent)
     {
-        if (distributedEvent == null)
-            throw new ArgumentNullException(nameof(distributedEvent));
+        ArgumentNullException.ThrowIfNull(distributedEvent);
 
         _distributedEvents.Add(distributedEvent);
         _version++; // Increment version for each distributed event

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/DistributedDomainEventBase.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/DistributedDomainEventBase.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace BBT.Aether.Domain.Events.Distributed;
+
+/// <summary>
+/// Base class for distributed domain events with common properties.
+/// </summary>
+public abstract class DistributedDomainEventBase : IDistributedDomainEvent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DistributedDomainEventBase"/> class.
+    /// </summary>
+    /// <param name="aggregateId">The ID of the aggregate that raised this event.</param>
+    /// <param name="aggregateType">The type of the aggregate that raised this event.</param>
+    /// <param name="aggregateVersion">The version of the aggregate when this event was raised.</param>
+    protected DistributedDomainEventBase(string aggregateId, string aggregateType, long aggregateVersion)
+    {
+        EventId = Guid.NewGuid().ToString();
+        OccurredOn = DateTime.UtcNow;
+        EventType = GetType().Name;
+        AggregateId = aggregateId ?? throw new ArgumentNullException(nameof(aggregateId));
+        AggregateType = aggregateType ?? throw new ArgumentNullException(nameof(aggregateType));
+        AggregateVersion = aggregateVersion;
+    }
+
+    /// <inheritdoc />
+    public string EventId { get; }
+
+    /// <inheritdoc />
+    public DateTime OccurredOn { get; }
+
+    /// <inheritdoc />
+    public string EventType { get; }
+
+    /// <inheritdoc />
+    public string AggregateId { get; }
+
+    /// <inheritdoc />
+    public string AggregateType { get; }
+
+    /// <inheritdoc />
+    public long AggregateVersion { get; }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/IDistributedDomainEvent.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/IDistributedDomainEvent.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace BBT.Aether.Domain.Events.Distributed;
+
+/// <summary>
+/// Base interface for distributed domain events.
+/// These events are published to external systems (message brokers, event stores, etc.)
+/// </summary>
+public interface IDistributedDomainEvent
+{
+    /// <summary>
+    /// Gets the unique identifier for this event.
+    /// </summary>
+    string EventId { get; }
+    
+    /// <summary>
+    /// Gets the date and time when the event occurred.
+    /// </summary>
+    DateTime OccurredOn { get; }
+    
+    /// <summary>
+    /// Gets the event type name for routing and deserialization.
+    /// </summary>
+    string EventType { get; }
+    
+    /// <summary>
+    /// Gets the aggregate ID that raised this event.
+    /// </summary>
+    string AggregateId { get; }
+    
+    /// <summary>
+    /// Gets the aggregate type that raised this event.
+    /// </summary>
+    string AggregateType { get; }
+    
+    /// <summary>
+    /// Gets the version of the aggregate when this event was raised.
+    /// </summary>
+    long AggregateVersion { get; }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/IDistributedDomainEventPublisher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/IDistributedDomainEventPublisher.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BBT.Aether.Domain.Events.Distributed;
+
+/// <summary>
+/// Defines a publisher for distributed domain events.
+/// </summary>
+public interface IDistributedDomainEventPublisher
+{
+    /// <summary>
+    /// Publishes distributed domain events to external systems.
+    /// </summary>
+    /// <param name="events">The distributed events to publish.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task PublishAsync(IEnumerable<IDistributedDomainEvent> events, CancellationToken cancellationToken = default);
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/NullDistributedDomainEventPublisher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/Distributed/NullDistributedDomainEventPublisher.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BBT.Aether.Domain.Events.Distributed;
+
+/// <summary>
+/// A null object implementation of <see cref="IDistributedDomainEventPublisher"/> that does nothing.
+/// This is useful for scenarios where distributed events are not needed, such as design-time contexts,
+/// migrations, or testing scenarios.
+/// </summary>
+public sealed class NullDistributedDomainEventPublisher : IDistributedDomainEventPublisher
+{
+    /// <summary>
+    /// Gets the singleton instance of the null distributed domain event publisher.
+    /// </summary>
+    public static readonly NullDistributedDomainEventPublisher Instance = new();
+
+    private NullDistributedDomainEventPublisher()
+    {
+    }
+
+    /// <inheritdoc />
+    public Task PublishAsync(IEnumerable<IDistributedDomainEvent> events, CancellationToken cancellationToken = default)
+    {
+        // Do nothing - this is a null object implementation
+        return Task.CompletedTask;
+    }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/DomainEventDispatcher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/DomainEventDispatcher.cs
@@ -66,7 +66,7 @@ public sealed class DomainEventDispatcher : IDomainEventDispatcher
         // Check if handler implements IOrderedDomainEventHandler<TEvent>
         var orderedHandlerType = typeof(IOrderedDomainEventHandler<>).MakeGenericType(eventType);
         
-        if (orderedHandlerType.IsAssignableFrom(handler.GetType()))
+        if (orderedHandlerType.IsInstanceOfType(handler))
         {
             var orderProperty = orderedHandlerType.GetProperty(nameof(IOrderedDomainEventHandler<IDomainEvent>.Order));
             if (orderProperty?.GetValue(handler) is int order)

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/DomainEventDispatcher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/DomainEventDispatcher.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Default implementation of <see cref="IDomainEventDispatcher"/> that dispatches events to registered handlers.
+/// </summary>
+public sealed class DomainEventDispatcher : IDomainEventDispatcher
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DomainEventDispatcher"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider to resolve handlers from.</param>
+    public DomainEventDispatcher(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    /// <inheritdoc />
+    public async Task DispatchAsync(IEnumerable<IDomainEvent> events, CancellationToken cancellationToken = default)
+    {
+        if (events == null)
+            return;
+
+        foreach (var @event in events)
+        {
+            await DispatchEventAsync(@event, cancellationToken);
+        }
+    }
+
+    private async Task DispatchEventAsync(IDomainEvent @event, CancellationToken cancellationToken)
+    {
+        var eventType = @event.GetType();
+        var handlerType = typeof(IDomainEventHandler<>).MakeGenericType(eventType);
+        var enumerableHandlerType = typeof(IEnumerable<>).MakeGenericType(handlerType);
+        
+        var handlers = (IEnumerable<object>?)_serviceProvider.GetService(enumerableHandlerType) 
+                       ?? Array.Empty<object>();
+
+        // Sort handlers by order if they implement IOrderedDomainEventHandler
+        var orderedHandlers = handlers
+            .Select(handler => new
+            {
+                Handler = handler,
+                Order = GetHandlerOrder(handler, eventType)
+            })
+            .OrderBy(x => x.Order)
+            .Select(x => x.Handler);
+
+        foreach (var handler in orderedHandlers)
+        {
+            var handleMethod = handlerType.GetMethod(nameof(IDomainEventHandler<IDomainEvent>.HandleAsync))!;
+            var task = (Task)handleMethod.Invoke(handler, new object[] { @event, cancellationToken })!;
+            await task.ConfigureAwait(false);
+        }
+    }
+
+    private static int GetHandlerOrder(object handler, Type eventType)
+    {
+        // Check if handler implements IOrderedDomainEventHandler<TEvent>
+        var orderedHandlerType = typeof(IOrderedDomainEventHandler<>).MakeGenericType(eventType);
+        
+        if (orderedHandlerType.IsAssignableFrom(handler.GetType()))
+        {
+            var orderProperty = orderedHandlerType.GetProperty(nameof(IOrderedDomainEventHandler<IDomainEvent>.Order));
+            if (orderProperty?.GetValue(handler) is int order)
+            {
+                return order;
+            }
+        }
+
+        // Default order is 0 for handlers that don't implement IOrderedDomainEventHandler
+        return 0;
+    }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/DomainEventDispatcher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/DomainEventDispatcher.cs
@@ -40,10 +40,8 @@ public sealed class DomainEventDispatcher : IDomainEventDispatcher
     {
         var eventType = @event.GetType();
         var handlerType = typeof(IDomainEventHandler<>).MakeGenericType(eventType);
-        var enumerableHandlerType = typeof(IEnumerable<>).MakeGenericType(handlerType);
         
-        var handlers = (IEnumerable<object>?)_serviceProvider.GetService(enumerableHandlerType) 
-                       ?? Array.Empty<object>();
+        var handlers = _serviceProvider.GetServices(handlerType).Cast<object>();
 
         // Sort handlers by order if they implement IOrderedDomainEventHandler
         var orderedHandlers = handlers

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/EventContext.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/EventContext.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.Events.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Default implementation of <see cref="IEventContext"/> that provides unified event handling.
+/// Manages pre-commit, post-commit, and distributed events through their respective handlers.
+/// </summary>
+public sealed class EventContext : IEventContext
+{
+    private readonly IDomainEventDispatcher? _domainEventDispatcher;
+    private readonly IDistributedDomainEventPublisher? _distributedEventPublisher;
+    private readonly ILogger<EventContext> _logger;
+    private readonly List<IPostCommitEvent> _storedPostCommitEvents = new();
+    private readonly List<IDistributedDomainEvent> _storedDistributedEvents = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventContext"/> class.
+    /// </summary>
+    /// <param name="domainEventDispatcher">The domain event dispatcher for local events.</param>
+    /// <param name="distributedEventPublisher">The distributed event publisher for external events.</param>
+    /// <param name="logger">The logger instance.</param>
+    public EventContext(
+        IDomainEventDispatcher? domainEventDispatcher,
+        IDistributedDomainEventPublisher? distributedEventPublisher,
+        ILogger<EventContext> logger)
+    {
+        _domainEventDispatcher = domainEventDispatcher;
+        _distributedEventPublisher = distributedEventPublisher;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public bool HasStoredEvents => _storedPostCommitEvents.Count > 0 || _storedDistributedEvents.Count > 0;
+
+    /// <inheritdoc />
+    public async Task DispatchPreCommitEventsAsync(IEnumerable<IPreCommitEvent> events, CancellationToken cancellationToken = default)
+    {
+        if (events?.Any() != true)
+        {
+            _logger.LogDebug("No pre-commit events to dispatch");
+            return;
+        }
+
+        if (_domainEventDispatcher == null)
+        {
+            _logger.LogWarning("No domain event dispatcher registered. Pre-commit events will be ignored");
+            return;
+        }
+
+        var eventList = events.ToList();
+        _logger.LogDebug("Dispatching {Count} pre-commit events", eventList.Count);
+
+        try
+        {
+            await _domainEventDispatcher.DispatchAsync(eventList, cancellationToken);
+            _logger.LogDebug("Successfully dispatched {Count} pre-commit events", eventList.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch {Count} pre-commit events", eventList.Count);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DispatchPostCommitEventsAsync(IEnumerable<IPostCommitEvent> events, CancellationToken cancellationToken = default)
+    {
+        if (events?.Any() != true)
+        {
+            _logger.LogDebug("No post-commit events to dispatch");
+            return;
+        }
+
+        if (_domainEventDispatcher == null)
+        {
+            _logger.LogWarning("No domain event dispatcher registered. Post-commit events will be ignored");
+            return;
+        }
+
+        var eventList = events.ToList();
+        _logger.LogDebug("Dispatching {Count} post-commit events", eventList.Count);
+
+        try
+        {
+            await _domainEventDispatcher.DispatchAsync(eventList, cancellationToken);
+            _logger.LogDebug("Successfully dispatched {Count} post-commit events", eventList.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch {Count} post-commit events", eventList.Count);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task PublishDistributedEventsAsync(IEnumerable<IDistributedDomainEvent> events, CancellationToken cancellationToken = default)
+    {
+        if (events?.Any() != true)
+        {
+            _logger.LogDebug("No distributed events to publish");
+            return;
+        }
+
+        if (_distributedEventPublisher == null)
+        {
+            _logger.LogWarning("No distributed event publisher registered. Distributed events will be ignored");
+            return;
+        }
+
+        var eventList = events.ToList();
+        _logger.LogDebug("Publishing {Count} distributed events", eventList.Count);
+
+        try
+        {
+            await _distributedEventPublisher.PublishAsync(eventList, cancellationToken);
+            _logger.LogDebug("Successfully published {Count} distributed events", eventList.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to publish {Count} distributed events", eventList.Count);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public void StorePostCommitEvents(IEnumerable<IPostCommitEvent> events)
+    {
+        if (events?.Any() == true)
+        {
+            var eventList = events.ToList();
+            _storedPostCommitEvents.AddRange(eventList);
+            _logger.LogDebug("Stored {Count} post-commit events for later dispatch", eventList.Count);
+        }
+    }
+
+    /// <inheritdoc />
+    public void StoreDistributedEvents(IEnumerable<IDistributedDomainEvent> events)
+    {
+        if (events?.Any() == true)
+        {
+            var eventList = events.ToList();
+            _storedDistributedEvents.AddRange(eventList);
+            _logger.LogDebug("Stored {Count} distributed events for later dispatch", eventList.Count);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DispatchStoredEventsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Dispatch stored post-commit events
+            if (_storedPostCommitEvents.Count > 0)
+            {
+                _logger.LogDebug("Dispatching {Count} stored post-commit events", _storedPostCommitEvents.Count);
+                await DispatchPostCommitEventsAsync(_storedPostCommitEvents, cancellationToken);
+            }
+
+            // Publish stored distributed events
+            if (_storedDistributedEvents.Count > 0)
+            {
+                _logger.LogDebug("Publishing {Count} stored distributed events", _storedDistributedEvents.Count);
+                await PublishDistributedEventsAsync(_storedDistributedEvents, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch stored events. Database changes are already committed.");
+            // Note: We don't rethrow here because the database transaction was already committed successfully
+            // Event dispatch failures should be handled separately (e.g., retry mechanisms, dead letter queues)
+        }
+    }
+
+    /// <inheritdoc />
+    public void ClearStoredEvents()
+    {
+        if (_storedPostCommitEvents.Count > 0 || _storedDistributedEvents.Count > 0)
+        {
+            _logger.LogDebug("Clearing {PostCommitCount} stored post-commit events and {DistributedCount} stored distributed events", 
+                _storedPostCommitEvents.Count, _storedDistributedEvents.Count);
+            
+            _storedPostCommitEvents.Clear();
+            _storedDistributedEvents.Clear();
+        }
+    }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/EventContext.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/EventContext.cs
@@ -65,7 +65,7 @@ public sealed class EventContext : IEventContext
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to dispatch {Count} pre-commit events", eventList.Count);
-            throw;
+                
         }
     }
 
@@ -95,7 +95,7 @@ public sealed class EventContext : IEventContext
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to dispatch {Count} post-commit events", eventList.Count);
-            throw;
+            throw new InvalidOperationException($"Failed to dispatch {eventList.Count} post-commit events", ex);
         }
     }
 
@@ -125,7 +125,7 @@ public sealed class EventContext : IEventContext
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to publish {Count} distributed events", eventList.Count);
-            throw;
+            throw new InvalidOperationException($"Failed to publish {eventList.Count} distributed events", ex);
         }
     }
 

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IDomainEvent.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IDomainEvent.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Base interface for domain events.
+/// </summary>
+public interface IDomainEvent
+{
+    /// <summary>
+    /// Gets the date and time when the event occurred.
+    /// </summary>
+    DateTime OccurredOn { get; }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IDomainEventDispatcher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IDomainEventDispatcher.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Defines a dispatcher for domain events.
+/// </summary>
+public interface IDomainEventDispatcher
+{
+    /// <summary>
+    /// Dispatches the specified domain events to their respective handlers.
+    /// </summary>
+    /// <param name="events">The domain events to dispatch.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DispatchAsync(IEnumerable<IDomainEvent> events, CancellationToken cancellationToken = default);
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IDomainEventHandler.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IDomainEventHandler.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Defines a handler for domain events.
+/// </summary>
+/// <typeparam name="TEvent">The type of domain event to handle.</typeparam>
+public interface IDomainEventHandler<in TEvent> where TEvent : IDomainEvent
+{
+    /// <summary>
+    /// Handles the specified domain event.
+    /// </summary>
+    /// <param name="event">The domain event to handle.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task HandleAsync(TEvent @event, CancellationToken cancellationToken = default);
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IEventContext.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IEventContext.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.Events.Distributed;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Provides a unified context for handling different types of domain events.
+/// This interface abstracts the complexity of managing pre-commit, post-commit, and distributed events.
+/// </summary>
+public interface IEventContext
+{
+    /// <summary>
+    /// Dispatches pre-commit events that should be processed within the same transaction.
+    /// </summary>
+    /// <param name="events">The pre-commit events to dispatch.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DispatchPreCommitEventsAsync(IEnumerable<IPreCommitEvent> events, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Dispatches post-commit events that should be processed after successful database commit.
+    /// </summary>
+    /// <param name="events">The post-commit events to dispatch.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DispatchPostCommitEventsAsync(IEnumerable<IPostCommitEvent> events, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes distributed events to external systems.
+    /// </summary>
+    /// <param name="events">The distributed events to publish.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task PublishDistributedEventsAsync(IEnumerable<IDistributedDomainEvent> events, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores post-commit events for later dispatch (used in transaction scenarios).
+    /// </summary>
+    /// <param name="events">The post-commit events to store.</param>
+    void StorePostCommitEvents(IEnumerable<IPostCommitEvent> events);
+
+    /// <summary>
+    /// Stores distributed events for later publishing (used in transaction scenarios).
+    /// </summary>
+    /// <param name="events">The distributed events to store.</param>
+    void StoreDistributedEvents(IEnumerable<IDistributedDomainEvent> events);
+
+    /// <summary>
+    /// Dispatches all stored events after successful transaction commit.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DispatchStoredEventsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears all stored events (used after dispatch or on rollback).
+    /// </summary>
+    void ClearStoredEvents();
+
+    /// <summary>
+    /// Gets whether there are any stored events waiting to be processed.
+    /// </summary>
+    bool HasStoredEvents { get; }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IOrderedDomainEventHandler.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IOrderedDomainEventHandler.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Defines an ordered handler for domain events.
+/// Handlers implementing this interface will be executed in order based on their Order property.
+/// </summary>
+/// <typeparam name="TEvent">The type of domain event to handle.</typeparam>
+public interface IOrderedDomainEventHandler<in TEvent> : IDomainEventHandler<TEvent> where TEvent : IDomainEvent
+{
+    /// <summary>
+    /// Gets the execution order of this handler.
+    /// Handlers with lower order values are executed first.
+    /// Default order is 0.
+    /// </summary>
+    int Order { get; }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IPostCommitEvent.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IPostCommitEvent.cs
@@ -1,0 +1,10 @@
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Marker interface for events that should be processed AFTER SaveChanges.
+/// Use this for events that represent side effects after data is persisted.
+/// This is the recommended approach for most domain events.
+/// </summary>
+public interface IPostCommitEvent : IDomainEvent
+{
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IPreCommitEvent.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/IPreCommitEvent.cs
@@ -1,0 +1,9 @@
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// Marker interface for events that should be processed BEFORE SaveChanges.
+/// Use this for events that need to be handled within the same transaction.
+/// </summary>
+public interface IPreCommitEvent : IDomainEvent
+{
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/NullDomainEventDispatcher.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Events/NullDomainEventDispatcher.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BBT.Aether.Domain.Events;
+
+/// <summary>
+/// A null object implementation of IDomainEventDispatcher that does nothing.
+/// Useful for design-time contexts, migrations, or testing scenarios.
+/// </summary>
+public sealed class NullDomainEventDispatcher : IDomainEventDispatcher
+{
+    public static readonly NullDomainEventDispatcher Instance = new();
+
+    private NullDomainEventDispatcher() { }
+
+    public Task DispatchAsync(IEnumerable<IDomainEvent> events, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask; // Do nothing
+    }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Services/ITransactionEventStorage.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Services/ITransactionEventStorage.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using BBT.Aether.Domain.Events;
+using BBT.Aether.Domain.Events.Distributed;
+
+namespace BBT.Aether.Domain.Services;
+
+/// <summary>
+/// Defines a service for storing domain events during transaction processing.
+/// Events stored here will be dispatched after successful transaction commit.
+/// </summary>
+public interface ITransactionEventStorage
+{
+    /// <summary>
+    /// Stores post-commit events to be dispatched after transaction commit.
+    /// </summary>
+    /// <param name="events">The post-commit events to store.</param>
+    void StorePostCommitEvents(IEnumerable<IPostCommitEvent> events);
+
+    /// <summary>
+    /// Stores distributed events to be published after transaction commit.
+    /// </summary>
+    /// <param name="events">The distributed events to store.</param>
+    void StoreDistributedEvents(IEnumerable<IDistributedDomainEvent> events);
+
+    /// <summary>
+    /// Gets whether there are any stored events waiting to be processed.
+    /// </summary>
+    bool HasStoredEvents { get; }
+}

--- a/framework/src/BBT.Aether.Domain/Microsoft/Extensions/DependencyInjection/AetherDomainEventsServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Domain/Microsoft/Extensions/DependencyInjection/AetherDomainEventsServiceCollectionExtensions.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using BBT.Aether.Domain.Events;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering domain events services.
+/// </summary>
+public static class AetherDomainEventsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds domain events support to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="assemblies">The assemblies to scan for domain event handlers.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDomainEvents(this IServiceCollection services, params Assembly[] assemblies)
+    {
+        if (services == null)
+            throw new ArgumentNullException(nameof(services));
+
+        // Register the domain event dispatcher
+        services.AddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+
+        // If no assemblies provided, use the calling assembly
+        if (assemblies == null || assemblies.Length == 0)
+        {
+            assemblies = new[] { Assembly.GetCallingAssembly() };
+        }
+
+        // Register all domain event handlers
+        RegisterDomainEventHandlers(services, assemblies);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds domain events support to the service collection with automatic assembly scanning.
+    /// This method will scan all loaded assemblies for domain event handlers.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDomainEventsFromLoadedAssemblies(this IServiceCollection services)
+    {
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .ToArray();
+
+        return services.AddDomainEvents(assemblies);
+    }
+
+    private static void RegisterDomainEventHandlers(IServiceCollection services, Assembly[] assemblies)
+    {
+        var handlerInterface = typeof(IDomainEventHandler<>);
+        
+        var handlerTypes = assemblies
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => !type.IsAbstract && !type.IsInterface && type.IsClass)
+            .Where(type => type.GetInterfaces()
+                .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == handlerInterface))
+            .ToList();
+
+        foreach (var handlerType in handlerTypes)
+        {
+            var implementedInterfaces = handlerType.GetInterfaces()
+                .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == handlerInterface)
+                .ToList();
+
+            foreach (var implementedInterface in implementedInterfaces)
+            {
+                services.AddScoped(implementedInterface, handlerType);
+            }
+        }
+    }
+}

--- a/framework/src/BBT.Aether.Domain/Microsoft/Extensions/DependencyInjection/AetherDomainEventsServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Domain/Microsoft/Extensions/DependencyInjection/AetherDomainEventsServiceCollectionExtensions.cs
@@ -21,8 +21,7 @@ public static class AetherDomainEventsServiceCollectionExtensions
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddDomainEvents(this IServiceCollection services, params Assembly[] assemblies)
     {
-        if (services == null)
-            throw new ArgumentNullException(nameof(services));
+        ArgumentNullException.ThrowIfNull(services);
 
         // Register the domain event dispatcher
         services.TryAddScoped<IDomainEventDispatcher, DomainEventDispatcher>();

--- a/framework/src/BBT.Aether.Domain/Microsoft/Extensions/DependencyInjection/AetherDomainEventsServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Domain/Microsoft/Extensions/DependencyInjection/AetherDomainEventsServiceCollectionExtensions.cs
@@ -2,7 +2,9 @@ using System;
 using System.Linq;
 using System.Reflection;
 using BBT.Aether.Domain.Events;
+using BBT.Aether.Domain.Events.Distributed;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -23,7 +25,13 @@ public static class AetherDomainEventsServiceCollectionExtensions
             throw new ArgumentNullException(nameof(services));
 
         // Register the domain event dispatcher
-        services.AddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+        services.TryAddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+        
+        // Register distributed event publisher if not already registered
+        services.TryAddScoped<IDistributedDomainEventPublisher, NullDistributedDomainEventPublisher>();
+        
+        // Register the unified event context
+        services.TryAddScoped<IEventContext, EventContext>();
 
         // If no assemblies provided, use the calling assembly
         if (assemblies == null || assemblies.Length == 0)

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/AetherDbContext.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/AetherDbContext.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using BBT.Aether.Domain.Entities;
 using BBT.Aether.Domain.EntityFrameworkCore.Modeling;
 using BBT.Aether.Domain.Events;
+using BBT.Aether.Domain.Events.Distributed;
+using BBT.Aether.Domain.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -17,12 +19,16 @@ namespace BBT.Aether.Domain.EntityFrameworkCore;
 
 public abstract class AetherDbContext<TDbContext>(
     DbContextOptions<TDbContext> options,
-    IDomainEventDispatcher? domainEventDispatcher = null
+    IDomainEventDispatcher? domainEventDispatcher = null,
+    IDistributedDomainEventPublisher? distributedEventPublisher = null,
+    ITransactionService? transactionService = null
 )
     : DbContext(options)
     where TDbContext : DbContext
 {
     private readonly IDomainEventDispatcher? _domainEventDispatcher = domainEventDispatcher;
+    private readonly IDistributedDomainEventPublisher? _distributedEventPublisher = distributedEventPublisher;
+    private readonly ITransactionService? _transactionService = transactionService;
     private readonly static MethodInfo ConfigureBasePropertiesMethodInfo
         = typeof(AetherDbContext<TDbContext>)
             .GetMethod(
@@ -57,7 +63,7 @@ public abstract class AetherDbContext<TDbContext>(
     {
         TrackEntityStates();
         
-        if (_domainEventDispatcher != null)
+        if (_domainEventDispatcher != null || _distributedEventPublisher != null)
         {
             return SaveChangesWithDomainEvents().GetAwaiter().GetResult();
         }
@@ -72,7 +78,7 @@ public abstract class AetherDbContext<TDbContext>(
         {
             TrackEntityStates();
             
-            if (_domainEventDispatcher != null)
+            if (_domainEventDispatcher != null || _distributedEventPublisher != null)
             {
                 return await SaveChangesWithDomainEvents(acceptAllChangesOnSuccess, cancellationToken);
             }
@@ -110,46 +116,121 @@ public abstract class AetherDbContext<TDbContext>(
 
     private async Task<int> SaveChangesWithDomainEvents(bool acceptAllChangesOnSuccess = true, CancellationToken cancellationToken = default)
     {
-        // 1) Collect domain events from tracked aggregate roots
+        // Check if we're in a transaction managed by ITransactionService
+        if (_transactionService?.HasActiveTransaction == true)
+        {
+            return await SaveChangesWithTransactionAwareEvents(acceptAllChangesOnSuccess, cancellationToken);
+        }
+
+        // Normal flow - no active transaction service
+        return await SaveChangesWithImmediateEvents(acceptAllChangesOnSuccess, cancellationToken);
+    }
+
+    private async Task<int> SaveChangesWithTransactionAwareEvents(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken)
+    {
+        // 1) Collect events from tracked aggregate roots
         var aggregates = ChangeTracker
             .Entries()
             .Where(e => e.Entity is IAggregateRoot)
             .Select(e => (IAggregateRoot)e.Entity)
             .ToList();
 
+        // 2) Collect events by type
         var preCommitEvents = aggregates
             .SelectMany(a => GetDomainEvents(a))
             .OfType<IPreCommitEvent>()
             .ToList();
 
-        // 2) Dispatch pre-commit events (within transaction)
-        if (preCommitEvents.Count > 0 && _domainEventDispatcher != null)
-        {
-            await _domainEventDispatcher.DispatchAsync(preCommitEvents, cancellationToken);
-        }
-
-        // 3) Commit changes to database
-        var result = await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
-
-        // 4) Dispatch post-commit events (after successful save)
         var postCommitEvents = aggregates
             .SelectMany(a => GetDomainEvents(a))
             .OfType<IPostCommitEvent>()
             .ToList();
 
+        var distributedEvents = aggregates
+            .SelectMany(a => GetDistributedEvents(a))
+            .ToList();
+
+        // 3) Dispatch pre-commit events (within transaction)
+        if (preCommitEvents.Count > 0 && _domainEventDispatcher != null)
+        {
+            await _domainEventDispatcher.DispatchAsync(preCommitEvents, cancellationToken);
+        }
+
+        // 4) Save changes to database
+        var result = await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+
+        // 5) Store post-commit and distributed events for later dispatch
+        if (_transactionService is ITransactionEventStorage eventStorage)
+        {
+            eventStorage.StorePostCommitEvents(postCommitEvents);
+            eventStorage.StoreDistributedEvents(distributedEvents);
+        }
+
+        // 6) Clear events from aggregates
+        foreach (var aggregate in aggregates)
+        {
+            ClearDomainEvents(aggregate);
+            ClearDistributedEvents(aggregate);
+        }
+
+        return result;
+    }
+
+    private async Task<int> SaveChangesWithImmediateEvents(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken)
+    {
+        // 1) Collect events from tracked aggregate roots
+        var aggregates = ChangeTracker
+            .Entries()
+            .Where(e => e.Entity is IAggregateRoot)
+            .Select(e => (IAggregateRoot)e.Entity)
+            .ToList();
+
+        // 2) Collect local events
+        var preCommitEvents = aggregates
+            .SelectMany(a => GetDomainEvents(a))
+            .OfType<IPreCommitEvent>()
+            .ToList();
+
+        var postCommitEvents = aggregates
+            .SelectMany(a => GetDomainEvents(a))
+            .OfType<IPostCommitEvent>()
+            .ToList();
+
+        // 3) Collect distributed events
+        var distributedEvents = aggregates
+            .SelectMany(a => GetDistributedEvents(a))
+            .ToList();
+
+        // 4) Dispatch pre-commit events (within transaction)
+        if (preCommitEvents.Count > 0 && _domainEventDispatcher != null)
+        {
+            await _domainEventDispatcher.DispatchAsync(preCommitEvents, cancellationToken);
+        }
+
+        // 5) Commit changes to database
+        var result = await base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+
         try
         {
+            // 6) Dispatch post-commit events (after successful save)
             if (postCommitEvents.Count > 0 && _domainEventDispatcher != null)
             {
                 await _domainEventDispatcher.DispatchAsync(postCommitEvents, cancellationToken);
             }
+
+            // 7) Publish distributed events (after local events)
+            if (distributedEvents.Count > 0 && _distributedEventPublisher != null)
+            {
+                await _distributedEventPublisher.PublishAsync(distributedEvents, cancellationToken);
+            }
         }
         finally
         {
-            // 5) Clear domain events from aggregates (important for idempotency)
+            // 8) Clear all events from aggregates (important for idempotency)
             foreach (var aggregate in aggregates)
             {
                 ClearDomainEvents(aggregate);
+                ClearDistributedEvents(aggregate);
             }
         }
 
@@ -175,6 +256,29 @@ public abstract class AetherDbContext<TDbContext>(
         // Use reflection to call ClearDomainEvents method from BasicAggregateRoot
         var clearMethod = aggregate.GetType()
             .GetMethod("ClearDomainEvents", BindingFlags.Public | BindingFlags.Instance);
+        
+        clearMethod?.Invoke(aggregate, null);
+    }
+
+    private static IEnumerable<IDistributedDomainEvent> GetDistributedEvents(IAggregateRoot aggregate)
+    {
+        // Use reflection to get DistributedEvents property from BasicAggregateRoot
+        var distributedEventsProperty = aggregate.GetType()
+            .GetProperty("DistributedEvents", BindingFlags.Public | BindingFlags.Instance);
+        
+        if (distributedEventsProperty?.GetValue(aggregate) is IEnumerable<IDistributedDomainEvent> events)
+        {
+            return events;
+        }
+
+        return Enumerable.Empty<IDistributedDomainEvent>();
+    }
+
+    private static void ClearDistributedEvents(IAggregateRoot aggregate)
+    {
+        // Use reflection to call ClearDistributedEvents method from BasicAggregateRoot
+        var clearMethod = aggregate.GetType()
+            .GetMethod("ClearDistributedEvents", BindingFlags.Public | BindingFlags.Instance);
         
         clearMethod?.Invoke(aggregate, null);
     }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/EfCoreTransactionService.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/EfCoreTransactionService.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BBT.Aether.Domain.Events;
+using BBT.Aether.Domain.Events.Distributed;
 using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Domain.Services;
 using Microsoft.EntityFrameworkCore;
@@ -14,14 +18,39 @@ namespace BBT.Aether.Domain.EntityFrameworkCore;
 /// Provides transaction management for Entity Framework Core DbContext.
 /// Handles database transactions with proper error handling and logging.
 /// </summary>
-public sealed class EfCoreTransactionService<TDbContext>(TDbContext dbContext, ILogger<EfCoreTransactionService<TDbContext>> logger)
-    : ITransactionService, ISupportsRollback
+public sealed class EfCoreTransactionService<TDbContext>(
+    TDbContext dbContext, 
+    ILogger<EfCoreTransactionService<TDbContext>> logger,
+    IDomainEventDispatcher? domainEventDispatcher = null,
+    IDistributedDomainEventPublisher? distributedEventPublisher = null)
+    : ITransactionService, ISupportsRollback, ITransactionEventStorage
     where TDbContext : DbContext
 {
     private IDbContextTransaction? _currentTransaction;
     private bool _disposed;
-    public bool HasActiveTransaction => _currentTransaction != null;
+    private readonly List<IPostCommitEvent> _postCommitEvents = new();
+    private readonly List<IDistributedDomainEvent> _distributedEvents = new();
 
+    public bool HasActiveTransaction => _currentTransaction != null;
+    public bool HasStoredEvents => _postCommitEvents.Count > 0 || _distributedEvents.Count > 0;
+
+    public void StorePostCommitEvents(IEnumerable<IPostCommitEvent> events)
+    {
+        if (events?.Any() == true)
+        {
+            _postCommitEvents.AddRange(events);
+            logger.LogDebug("Stored {Count} post-commit events for later dispatch", events.Count());
+        }
+    }
+
+    public void StoreDistributedEvents(IEnumerable<IDistributedDomainEvent> events)
+    {
+        if (events?.Any() == true)
+        {
+            _distributedEvents.AddRange(events);
+            logger.LogDebug("Stored {Count} distributed events for later dispatch", events.Count());
+        }
+    }
 
     public async Task BeginAsync(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
         CancellationToken cancellationToken = default)
@@ -50,9 +79,13 @@ public sealed class EfCoreTransactionService<TDbContext>(TDbContext dbContext, I
 
         try
         {
+            // First commit the database transaction
             await dbContext.SaveChangesAsync(cancellationToken);
             await _currentTransaction!.CommitAsync(cancellationToken);
             logger.LogDebug("Transaction successfully committed");
+
+            // After successful commit, dispatch stored events
+            await DispatchStoredEvents(cancellationToken);
         }
         catch (Exception ex)
         {
@@ -63,6 +96,7 @@ public sealed class EfCoreTransactionService<TDbContext>(TDbContext dbContext, I
         finally
         {
             await DisposeTransactionAsync();
+            ClearStoredEvents();
         }
     }
 
@@ -85,6 +119,7 @@ public sealed class EfCoreTransactionService<TDbContext>(TDbContext dbContext, I
         finally
         {
             await DisposeTransactionAsync();
+            ClearStoredEvents(); // Clear stored events on rollback
         }
     }
 
@@ -154,6 +189,43 @@ public sealed class EfCoreTransactionService<TDbContext>(TDbContext dbContext, I
             logger.LogDebug("Disposing current transaction");
             await _currentTransaction.DisposeAsync();
             _currentTransaction = null;
+        }
+    }
+
+    private async Task DispatchStoredEvents(CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Dispatch post-commit events
+            if (_postCommitEvents.Count > 0 && domainEventDispatcher != null)
+            {
+                logger.LogDebug("Dispatching {Count} post-commit events after successful transaction commit", _postCommitEvents.Count);
+                await domainEventDispatcher.DispatchAsync(_postCommitEvents, cancellationToken);
+            }
+
+            // Publish distributed events
+            if (_distributedEvents.Count > 0 && distributedEventPublisher != null)
+            {
+                logger.LogDebug("Publishing {Count} distributed events after successful transaction commit", _distributedEvents.Count);
+                await distributedEventPublisher.PublishAsync(_distributedEvents, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to dispatch events after successful transaction commit. Database changes are already committed.");
+            // Note: We don't rethrow here because the database transaction was already committed successfully
+            // Event dispatch failures should be handled separately (e.g., retry mechanisms, dead letter queues)
+        }
+    }
+
+    private void ClearStoredEvents()
+    {
+        if (_postCommitEvents.Count > 0 || _distributedEvents.Count > 0)
+        {
+            logger.LogDebug("Clearing {PostCommitCount} post-commit events and {DistributedCount} distributed events", 
+                _postCommitEvents.Count, _distributedEvents.Count);
+            _postCommitEvents.Clear();
+            _distributedEvents.Clear();
         }
     }
 }

--- a/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherEfCoreServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherEfCoreServiceCollectionExtensions.cs
@@ -2,10 +2,11 @@ using System;
 using BBT.Aether.Domain.EntityFrameworkCore;
 using BBT.Aether.Domain.EntityFrameworkCore.Interceptors;
 using BBT.Aether.Domain.Events;
-using BBT.Aether.Domain.Repositories;
+using BBT.Aether.Domain.Events.Distributed;
 using BBT.Aether.Domain.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -20,6 +21,9 @@ public static class AetherEfCoreServiceCollectionExtensions
 
         // Register domain event dispatcher if not already registered
         services.TryAddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+
+        // Register distributed event publisher if not already registered
+        services.TryAddScoped<IDistributedDomainEventPublisher, NullDistributedDomainEventPublisher>();
 
         services.AddDbContext<TDbContext>((sp, dbContextOptions) =>
         {
@@ -46,6 +50,9 @@ public static class AetherEfCoreServiceCollectionExtensions
         
         // Register domain event dispatcher if not already registered
         services.TryAddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+
+        // Register distributed event publisher if not already registered
+        services.TryAddScoped<IDistributedDomainEventPublisher, NullDistributedDomainEventPublisher>();
         
         // Configure DbContextOptions
         services.AddDbContextOptions<TDbContext>(options);
@@ -69,6 +76,20 @@ public static class AetherEfCoreServiceCollectionExtensions
             return builder.Options;
         });
 
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a custom distributed domain event publisher implementation.
+    /// </summary>
+    /// <typeparam name="TPublisher">The type of the distributed event publisher.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDistributedDomainEventPublisher<TPublisher>(
+        this IServiceCollection services)
+        where TPublisher : class, IDistributedDomainEventPublisher
+    {
+        services.Replace(ServiceDescriptor.Scoped<IDistributedDomainEventPublisher, TPublisher>());
         return services;
     }
 }

--- a/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherEfCoreServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherEfCoreServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 using System;
 using BBT.Aether.Domain.EntityFrameworkCore;
 using BBT.Aether.Domain.EntityFrameworkCore.Interceptors;
+using BBT.Aether.Domain.Events;
 using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Domain.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,10 @@ public static class AetherEfCoreServiceCollectionExtensions
         where TDbContext : DbContext
     {
         services.AddSingleton<AuditInterceptor>();
+
+        // Register domain event dispatcher if not already registered
+        services.TryAddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+
         services.AddDbContext<TDbContext>((sp, dbContextOptions) =>
         {
             options?.Invoke(dbContextOptions);
@@ -24,6 +30,45 @@ public static class AetherEfCoreServiceCollectionExtensions
         });
 
         services.AddScoped<ITransactionService, EfCoreTransactionService<TDbContext>>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds IDbContextFactory with domain events support.
+    /// </summary>
+    public static IServiceCollection AddAetherDbContextFactory<TDbContext, TFactory>(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> options)
+        where TDbContext : AetherDbContext<TDbContext>
+        where TFactory : class, IDbContextFactory<TDbContext>
+    {
+        services.AddSingleton<AuditInterceptor>();
+        
+        // Register domain event dispatcher if not already registered
+        services.TryAddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+        
+        // Configure DbContextOptions
+        services.AddDbContextOptions<TDbContext>(options);
+        
+        // Register the factory
+        services.AddScoped<IDbContextFactory<TDbContext>, TFactory>();
+        services.AddScoped<TFactory>();
+
+        return services;
+    }
+
+    private static IServiceCollection AddDbContextOptions<TDbContext>(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> options)
+        where TDbContext : DbContext
+    {
+        services.AddSingleton<DbContextOptions<TDbContext>>(sp =>
+        {
+            var builder = new DbContextOptionsBuilder<TDbContext>();
+            options?.Invoke(builder);
+            return builder.Options;
+        });
+
         return services;
     }
 }

--- a/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherEfCoreServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherEfCoreServiceCollectionExtensions.cs
@@ -24,6 +24,9 @@ public static class AetherEfCoreServiceCollectionExtensions
 
         // Register distributed event publisher if not already registered
         services.TryAddScoped<IDistributedDomainEventPublisher, NullDistributedDomainEventPublisher>();
+        
+        // Register the unified event context
+        services.TryAddScoped<IEventContext, EventContext>();
 
         services.AddDbContext<TDbContext>((sp, dbContextOptions) =>
         {
@@ -53,6 +56,9 @@ public static class AetherEfCoreServiceCollectionExtensions
 
         // Register distributed event publisher if not already registered
         services.TryAddScoped<IDistributedDomainEventPublisher, NullDistributedDomainEventPublisher>();
+        
+        // Register the unified event context
+        services.TryAddScoped<IEventContext, EventContext>();
         
         // Configure DbContextOptions
         services.AddDbContextOptions<TDbContext>(options);


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive support for local and distributed domain events, wiring up event raising in aggregates, pre- and post-commit dispatch in DbContext and transaction service, default dispatchers and publishers, and DI helpers to register event components

New Features:
- Integrate domain event dispatching and distributed event publishing into DbContext SaveChanges pipeline
- Add mechanisms in BasicAggregateRoot to raise, track, and clear local and distributed domain events with versioning
- Enhance EfCoreTransactionService to store events during transactions and dispatch them post-commit with rollback support
- Introduce core domain event library including dispatcher, null implementations, event interfaces, and base distributed event class
- Provide DI extension methods to auto-register domain event dispatchers, handlers, and distributed event publishers, including DbContextFactory support

Enhancements:
- Refine correlation ID extraction in AetherCorrelationIdMiddleware for improved header handling
- Remove unused imports in HeaderLogEnricher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive domain & distributed event system: event contracts, base class, ordered handlers, dispatcher, null-object publishers, and an event context for orchestration.
  * Integrated event processing into persistence and transactions: DbContext, transaction service, and event context now collect, stage, dispatch, and publish pre/post-commit and distributed events.
  * DI extensions to register domain events, publishers, and DbContext factory support.

* **Bug Fixes**
  * Improved correlation ID handling: trims/ignores whitespace, falls back to TraceIdentifier or new GUID, and stores resolved ID in request headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->