### PR TITLE
Add BBT.Aether.Aspects to NuGet publish workflow

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -140,6 +140,7 @@ jobs:
           "./framework/src/BBT.Aether.AspNetCore/BBT.Aether.AspNetCore.csproj"
           "./framework/src/BBT.Aether.TestBase/BBT.Aether.TestBase.csproj"
           "./framework/src/BBT.Aether.HttpClient/BBT.Aether.HttpClient.csproj"
+          "./framework/src/BBT.Aether.Aspects/BBT.Aether.Aspects.csproj"
         )
         
         # Check for module projects (if they exist)


### PR DESCRIPTION
Included the BBT.Aether.Aspects project in the list of projects to be published by the GitHub Actions NuGet workflow.

## Summary by Sourcery

CI:
- Add BBT.Aether.Aspects project to the list of projects published by the NuGet workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated NuGet publishing workflow to include the Aspects project in package creation and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->