### PR TITLE
Update error logs to reference Dapr lock

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://context7.com/burgan-tech/aether",
+    "public_key": "pk_xcxndUScZajJjJ9rVxWsI"
+  }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/DistributedLock/Dapr/DaprDistributedLockService.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/DistributedLock/Dapr/DaprDistributedLockService.cs
@@ -77,7 +77,7 @@ public class DaprDistributedLockService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error executing function with Redis lock for resource {ResourceId}", resourceId);
+            logger.LogError(ex, "Error executing function with Dapr lock for resource {ResourceId}", resourceId);
             throw;
         }
     }
@@ -102,7 +102,7 @@ public class DaprDistributedLockService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error executing action with Redis lock for resource {ResourceId}", resourceId);
+            logger.LogError(ex, "Error executing action with Dapr lock for resource {ResourceId}", resourceId);
             throw;
         }
     }


### PR DESCRIPTION
Changed error log messages in DaprDistributedLockService to correctly reference 'Dapr lock' instead of 'Redis lock'. Added new context7.json configuration file.

## Summary by Sourcery

Update distributed locking logging to correctly reference the Dapr-based lock implementation and add a new configuration context file.

Enhancements:
- Correct error log messages in DaprDistributedLockService to reference the Dapr lock instead of Redis.

Chores:
- Add a new context7.json configuration file placeholder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration
  * Enhanced diagnostic logging for distributed locking operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->