### PR TITLE
Release v1.0

### DIFF
--- a/framework/src/BBT.Aether.Application/BBT/Aether/Application/Dtos/HateoasPagedResultDto.cs
+++ b/framework/src/BBT.Aether.Application/BBT/Aether/Application/Dtos/HateoasPagedResultDto.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace BBT.Aether.Application.Dtos;
+
+/// <summary>
+/// Paged result DTO with HATEOAS navigation links.
+/// Optimized for performance - TotalCount is optional (null when using N+1 strategy).
+/// </summary>
+[Serializable]
+public class HateoasPagedResultDto<T> : ListResultDto<T>
+{
+    /// <summary>
+    /// HATEOAS navigation links for pagination.
+    /// </summary>
+    public PaginationLinks Links { get; set; } = new();
+
+    /// <summary>
+    /// Creates a new <see cref="HateoasPagedResultDto{T}"/> object.
+    /// </summary>
+    public HateoasPagedResultDto()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="HateoasPagedResultDto{T}"/> object without TotalCount (HATEOAS optimized).
+    /// </summary>
+    /// <param name="items">List of items in current page</param>
+    /// <param name="links">HATEOAS pagination links</param>
+    public HateoasPagedResultDto(IReadOnlyList<T> items, PaginationLinks links)
+    {
+        Items = items;
+        Links = links;
+    }
+}

--- a/framework/src/BBT.Aether.Application/BBT/Aether/Application/Dtos/PaginationLinks.cs
+++ b/framework/src/BBT.Aether.Application/BBT/Aether/Application/Dtos/PaginationLinks.cs
@@ -1,0 +1,29 @@
+namespace BBT.Aether.Application.Dtos;
+
+/// <summary>
+/// HATEOAS pagination links for API responses.
+/// Provides navigation links for paginated results.
+/// </summary>
+public class PaginationLinks
+{
+    /// <summary>
+    /// Link to the current page.
+    /// </summary>
+    public string Self { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link to the first page.
+    /// </summary>
+    public string First { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link to the next page. Empty if no next page exists.
+    /// </summary>
+    public string Next { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link to the previous page. Empty if on first page.
+    /// </summary>
+    public string Prev { get; set; } = string.Empty;
+}
+

--- a/framework/src/BBT.Aether.Application/BBT/Aether/Domain/Pagination/IPaginationLinkGenerator.cs
+++ b/framework/src/BBT.Aether.Application/BBT/Aether/Domain/Pagination/IPaginationLinkGenerator.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using BBT.Aether.Application.Dtos;
+using BBT.Aether.Domain.Repositories;
+
+namespace BBT.Aether.Domain.Pagination;
+
+/// <summary>
+/// Generates HATEOAS pagination links for API responses.
+/// Should be used in the API/Controller layer only.
+/// </summary>
+public interface IPaginationLinkGenerator
+{
+    /// <summary>
+    /// Generates pagination links based on the current request context.
+    /// Uses HateoasPagedList which is optimized for performance (no TotalCount).
+    /// </summary>
+    /// <typeparam name="T">The type of paginated items.</typeparam>
+    /// <param name="pagedList">The paginated data from repository (HATEOAS optimized).</param>
+    /// <param name="routePath">The route path (e.g., "instances", "users").</param>
+    /// <returns>HATEOAS pagination links.</returns>
+    PaginationLinks GenerateLinks<T>(HateoasPagedList<T> pagedList, string routePath);
+
+    /// <summary>
+    /// Creates a complete HATEOAS paged result by combining mapped items with generated links.
+    /// Uses HateoasPagedList which is optimized for performance (no TotalCount).
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type from the repository.</typeparam>
+    /// <typeparam name="TDto">The DTO type for the response.</typeparam>
+    /// <param name="pagedList">The paginated data from repository (HATEOAS optimized).</param>
+    /// <param name="items">The mapped DTO items.</param>
+    /// <param name="routePath">The route path (e.g., "instances", "users").</param>
+    /// <returns>HATEOAS paged result with items and navigation links.</returns>
+    HateoasPagedResultDto<TDto> CreateHateoasResult<TEntity, TDto>(
+        HateoasPagedList<TEntity> pagedList,
+        IReadOnlyList<TDto> items,
+        string routePath);
+
+    /// <summary>
+    /// Generates pagination links for standard PagedList (includes TotalCount).
+    /// Use this when you need total count information.
+    /// </summary>
+    /// <typeparam name="T">The type of paginated items.</typeparam>
+    /// <param name="pagedList">The paginated data from repository.</param>
+    /// <param name="routePath">The route path (e.g., "instances", "users").</param>
+    /// <returns>HATEOAS pagination links.</returns>
+    PaginationLinks GenerateLinks<T>(PagedList<T> pagedList, string routePath);
+
+    /// <summary>
+    /// Creates a complete HATEOAS paged result using standard PagedList.
+    /// Use this when you need total count information.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type from the repository.</typeparam>
+    /// <typeparam name="TDto">The DTO type for the response.</typeparam>
+    /// <param name="pagedList">The paginated data from repository.</param>
+    /// <param name="items">The mapped DTO items.</param>
+    /// <param name="routePath">The route path (e.g., "instances", "users").</param>
+    /// <returns>HATEOAS paged result with items, navigation links, and total count.</returns>
+    HateoasPagedResultDto<TDto> CreateHateoasResult<TEntity, TDto>(
+        PagedList<TEntity> pagedList,
+        IReadOnlyList<TDto> items,
+        string routePath);
+}
+

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/Domain/Pagination/PaginationLinkGenerator.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/Domain/Pagination/PaginationLinkGenerator.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BBT.Aether.Application.Dtos;
+using BBT.Aether.Domain.Repositories;
+using Microsoft.AspNetCore.Http;
+
+namespace BBT.Aether.Domain.Pagination;
+
+/// <summary>
+/// Generates HATEOAS pagination links using the current HTTP request context.
+/// Supports reverse proxy scenarios via X-Forwarded-* headers.
+/// </summary>
+public sealed class PaginationLinkGenerator : IPaginationLinkGenerator
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    /// <summary>
+    /// Initializes the PaginationLinkGenerator with HTTP context accessor.
+    /// </summary>
+    /// <param name="httpContextAccessor">Accessor for the current HTTP context.</param>
+    public PaginationLinkGenerator(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <inheritdoc />
+    public PaginationLinks GenerateLinks<T>(HateoasPagedList<T> pagedList, string routePath)
+    {
+        var baseUrl = GetBaseUrl();
+        var route = routePath.TrimStart('/');
+        var queryParams = GetCurrentQueryParams();
+
+        return new PaginationLinks
+        {
+            Self = BuildPageLink(baseUrl, route, pagedList.CurrentPage, pagedList.PageSize, queryParams),
+            First = BuildPageLink(baseUrl, route, 1, pagedList.PageSize, queryParams),
+            Next = pagedList.HasNext
+                ? BuildPageLink(baseUrl, route, pagedList.CurrentPage + 1, pagedList.PageSize, queryParams)
+                : string.Empty,
+            Prev = pagedList.HasPrevious
+                ? BuildPageLink(baseUrl, route, pagedList.CurrentPage - 1, pagedList.PageSize, queryParams)
+                : string.Empty
+        };
+    }
+
+    /// <inheritdoc />
+    public HateoasPagedResultDto<TDto> CreateHateoasResult<TEntity, TDto>(
+        HateoasPagedList<TEntity> pagedList,
+        IReadOnlyList<TDto> items,
+        string routePath)
+    {
+        var links = GenerateLinks(pagedList, routePath);
+        return new HateoasPagedResultDto<TDto>(items, links);
+    }
+
+    /// <inheritdoc />
+    public PaginationLinks GenerateLinks<T>(PagedList<T> pagedList, string routePath)
+    {
+        var baseUrl = GetBaseUrl();
+        var route = routePath.TrimStart('/');
+        var queryParams = GetCurrentQueryParams();
+
+        return new PaginationLinks
+        {
+            Self = BuildPageLink(baseUrl, route, pagedList.CurrentPage, pagedList.PageSize, queryParams),
+            First = BuildPageLink(baseUrl, route, 1, pagedList.PageSize, queryParams),
+            Next = pagedList.HasNext
+                ? BuildPageLink(baseUrl, route, pagedList.CurrentPage + 1, pagedList.PageSize, queryParams)
+                : string.Empty,
+            Prev = pagedList.HasPrevious
+                ? BuildPageLink(baseUrl, route, pagedList.CurrentPage - 1, pagedList.PageSize, queryParams)
+                : string.Empty
+        };
+    }
+
+    /// <inheritdoc />
+    public HateoasPagedResultDto<TDto> CreateHateoasResult<TEntity, TDto>(
+        PagedList<TEntity> pagedList,
+        IReadOnlyList<TDto> items,
+        string routePath)
+    {
+        var links = GenerateLinks(pagedList, routePath);
+        return new HateoasPagedResultDto<TDto>(items, links);
+    }
+
+    /// <summary>
+    /// Gets the current request's query parameters.
+    /// </summary>
+    private IQueryCollection? GetCurrentQueryParams()
+    {
+        return _httpContextAccessor.HttpContext?.Request.Query;
+    }
+
+    /// <summary>
+    /// Gets the base URL from the current HTTP request.
+    /// Respects X-Forwarded-* headers for reverse proxy scenarios.
+    /// </summary>
+    private string GetBaseUrl()
+    {
+        var context = _httpContextAccessor.HttpContext;
+
+        if (context?.Request is null)
+        {
+            // Fallback for non-HTTP contexts (background jobs, tests)
+            return string.Empty;
+        }
+
+        var request = context.Request;
+
+        // Support for reverse proxy headers (X-Forwarded-Proto, X-Forwarded-Host)
+        var scheme = GetForwardedScheme(request) ?? request.Scheme;
+        var host = GetForwardedHost(request) ?? request.Host.ToString();
+        var pathBase = request.PathBase.ToString().TrimEnd('/');
+
+        return $"{scheme}://{host}{pathBase}";
+    }
+
+    /// <summary>
+    /// Gets the forwarded scheme from X-Forwarded-Proto header.
+    /// </summary>
+    private static string? GetForwardedScheme(HttpRequest request)
+    {
+        if (request.Headers.TryGetValue("X-Forwarded-Proto", out var proto) &&
+            !string.IsNullOrEmpty(proto))
+        {
+            return proto.ToString().Split(',')[0].Trim();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the forwarded host from X-Forwarded-Host header.
+    /// </summary>
+    private static string? GetForwardedHost(HttpRequest request)
+    {
+        if (request.Headers.TryGetValue("X-Forwarded-Host", out var host) &&
+            !string.IsNullOrEmpty(host))
+        {
+            return host.ToString().Split(',')[0].Trim();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Builds a complete page link with all query parameters.
+    /// </summary>
+    private static string BuildPageLink(
+        string baseUrl,
+        string route,
+        int page,
+        int pageSize,
+        IQueryCollection? queryParams)
+    {
+        var sb = new StringBuilder();
+        sb.Append(baseUrl);
+
+        if (!string.IsNullOrEmpty(route))
+        {
+            sb.Append('/');
+            sb.Append(route);
+        }
+
+        sb.Append('?');
+        sb.Append("page=");
+        sb.Append(page);
+        sb.Append("&pageSize=");
+        sb.Append(pageSize);
+
+        if (queryParams is not null)
+        {
+            foreach (var param in queryParams)
+            {
+                // Skip pagination params - we're setting them ourselves
+                if (param.Key.Equals("page", StringComparison.OrdinalIgnoreCase) ||
+                    param.Key.Equals("pageSize", StringComparison.OrdinalIgnoreCase) ||
+                    param.Key.Equals("skipCount", StringComparison.OrdinalIgnoreCase) ||
+                    param.Key.Equals("maxResultCount", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                foreach (var value in param.Value)
+                {
+                    sb.Append('&');
+                    sb.Append(Uri.EscapeDataString(param.Key));
+                    sb.Append('=');
+                    sb.Append(Uri.EscapeDataString(value ?? string.Empty));
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/HateoasPagedList.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/HateoasPagedList.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+namespace BBT.Aether.Domain.Repositories;
+
+/// <summary>
+/// Represents a paged list optimized for HATEOAS responses.
+/// Does not include TotalCount for performance (avoids COUNT(*) query).
+/// Uses N+1 strategy to determine HasNext.
+/// </summary>
+/// <typeparam name="T">The type of the items in the list.</typeparam>
+public class HateoasPagedList<T>
+{
+    /// <summary>
+    /// Creates a new HateoasPagedList.
+    /// </summary>
+    /// <param name="items">The list of items for the current page.</param>
+    /// <param name="pageNumber">The current page number (1-based).</param>
+    /// <param name="pageSize">The size of each page.</param>
+    /// <param name="hasNext">Whether there is a next page.</param>
+    public HateoasPagedList(IList<T> items, int pageNumber, int pageSize, bool hasNext)
+    {
+        Items = items;
+        CurrentPage = pageNumber;
+        PageSize = pageSize;
+        HasNext = hasNext;
+    }
+
+    /// <summary>
+    /// Gets the current page number (1-based).
+    /// </summary>
+    public int CurrentPage { get; }
+
+    /// <summary>
+    /// Gets the size of each page.
+    /// </summary>
+    public int PageSize { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether there is a previous page.
+    /// </summary>
+    public bool HasPrevious => CurrentPage > 1;
+
+    /// <summary>
+    /// Gets a value indicating whether there is a next page.
+    /// Determined by N+1 strategy without COUNT(*) query.
+    /// </summary>
+    public bool HasNext { get; }
+
+    /// <summary>
+    /// Gets the list of items for the current page.
+    /// </summary>
+    public IList<T> Items { get; }
+}
+

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/QueryableExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/QueryableExtensions.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace BBT.Aether.Domain;
+
+/// <summary>
+/// Extension methods for IQueryable pagination operations.
+/// </summary>
+public static class QueryableExtensions
+{
+    /// <summary>
+    /// Asynchronously converts an IQueryable to a paginated PagedList.
+    /// Includes TotalCount (performs COUNT(*) query).
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the query.</typeparam>
+    /// <param name="query">The source query.</param>
+    /// <param name="pageNumber">The 1-based page number.</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A PagedList containing the paginated results with total count.</returns>
+    public async static Task<PagedList<T>> ToPagedListAsync<T>(
+        this IQueryable<T> query,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (pageNumber < 1)
+        {
+            pageNumber = 1;
+        }
+
+        if (pageSize < 1)
+        {
+            pageSize = 10;
+        }
+
+        var count = await query.LongCountAsync(cancellationToken);
+
+        var items = await query
+            .PageBy((pageNumber - 1) * pageSize, pageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedList<T>(items, count, pageNumber, pageSize);
+    }
+
+    /// <summary>
+    /// Asynchronously converts an IQueryable to a paginated PagedList using PaginationParameters.
+    /// Includes TotalCount (performs COUNT(*) query).
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the query.</typeparam>
+    /// <param name="query">The source query.</param>
+    /// <param name="parameters">The pagination parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A PagedList containing the paginated results with total count.</returns>
+    public async static Task<PagedList<T>> ToPagedListAsync<T>(
+        this IQueryable<T> query,
+        PaginationParameters parameters,
+        CancellationToken cancellationToken = default)
+    {
+        var pageSize = parameters.MaxResultCount;
+        var pageNumber = (parameters.SkipCount / pageSize) + 1;
+
+        return await query.ToPagedListAsync(pageNumber, pageSize, cancellationToken);
+    }
+
+    /// <summary>
+    /// Asynchronously converts an IQueryable to a HATEOAS-optimized HateoasPagedList.
+    /// Uses N+1 strategy to determine HasNext without COUNT(*) query for better performance.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the query.</typeparam>
+    /// <param name="query">The source query.</param>
+    /// <param name="pageNumber">The 1-based page number.</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A HateoasPagedList containing the paginated results (no TotalCount for performance).</returns>
+    public async static Task<HateoasPagedList<T>> ToHateoasPagedListAsync<T>(
+        this IQueryable<T> query,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (pageNumber < 1)
+        {
+            pageNumber = 1;
+        }
+
+        if (pageSize < 1)
+        {
+            pageSize = 10;
+        }
+
+        var skip = (pageNumber - 1) * pageSize;
+
+        // Fetch pageSize + 1 items to determine if there's a next page
+        var items = await query
+            .PageBy(skip, pageSize + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasNext = items.Count > pageSize;
+
+        // Remove the extra item if exists
+        if (hasNext)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        return new HateoasPagedList<T>(items, pageNumber, pageSize, hasNext);
+    }
+
+    /// <summary>
+    /// Asynchronously converts an IQueryable to a HATEOAS-optimized HateoasPagedList using PaginationParameters.
+    /// Uses N+1 strategy to determine HasNext without COUNT(*) query for better performance.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the query.</typeparam>
+    /// <param name="query">The source query.</param>
+    /// <param name="parameters">The pagination parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A HateoasPagedList containing the paginated results (no TotalCount for performance).</returns>
+    public async static Task<HateoasPagedList<T>> ToHateoasPagedListAsync<T>(
+        this IQueryable<T> query,
+        PaginationParameters parameters,
+        CancellationToken cancellationToken = default)
+    {
+        var pageSize = parameters.MaxResultCount;
+        var pageNumber = (parameters.SkipCount / pageSize) + 1;
+
+        return await query.ToHateoasPagedListAsync(pageNumber, pageSize, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce framework-level support for HATEOAS-friendly pagination in ASP.NET Core APIs and wire it into the Aether ASP.NET Core module.

New Features:
- Add a PaginationLinkGenerator service and IPaginationLinkGenerator interface to generate HATEOAS pagination links based on the current HTTP request, including reverse proxy support.
- Introduce HateoasPagedList, HateoasPagedResultDto, and PaginationLinks types to represent paginated data and navigation links in API responses.
- Provide IQueryable extension methods to materialize queries into PagedList and HateoasPagedList instances, including overloads that accept PaginationParameters.

Enhancements:
- Register the PaginationLinkGenerator as a scoped service in the Aether ASP.NET Core module configuration.
- Tidy minor formatting in the ASP.NET Core response compression and exception handler configuration code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HATEOAS pagination support for paginated API responses with self, first, next, and previous page navigation links.
  * Introduced optimized pagination handling that eliminates total count queries for improved performance.
  * Automatically generates pagination links with support for reverse proxy headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->