### PR TITLE
Refactor pagination classes and update namespaces

### DIFF
--- a/framework/src/BBT.Aether.Application/BBT/Aether/Application/Contracts/IReadOnlyAppService.cs
+++ b/framework/src/BBT.Aether.Application/BBT/Aether/Application/Contracts/IReadOnlyAppService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using BBT.Aether.Application.Dtos;
+using BBT.Aether.Domain;
 using BBT.Aether.Domain.Repositories;
 
 namespace BBT.Aether.Application;

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Pagination/IPaginationLinkGenerator.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Pagination/IPaginationLinkGenerator.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using BBT.Aether.Application.Dtos;
-using BBT.Aether.Domain.Repositories;
 
-namespace BBT.Aether.Domain.Pagination;
+namespace BBT.Aether.AspNetCore.Pagination;
 
 /// <summary>
 /// Generates HATEOAS pagination links for API responses.

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Pagination/PaginationLinkGenerator.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Pagination/PaginationLinkGenerator.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using BBT.Aether.Application.Dtos;
-using BBT.Aether.Domain.Repositories;
 using Microsoft.AspNetCore.Http;
 
-namespace BBT.Aether.Domain.Pagination;
+namespace BBT.Aether.AspNetCore.Pagination;
 
 /// <summary>
 /// Generates HATEOAS pagination links using the current HTTP request context.

--- a/framework/src/BBT.Aether.AspNetCore/Microsoft/Extensions/DependencyInjection/AetherAspNetCoreModuleServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.AspNetCore/Microsoft/Extensions/DependencyInjection/AetherAspNetCoreModuleServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 using System;
 using System.IO.Compression;
 using System.Linq;
-using BBT.Aether.Domain.Pagination;
 using BBT.Aether.AspNetCore.ExceptionHandling;
+using BBT.Aether.AspNetCore.Pagination;
 using BBT.Aether.AspNetCore.Security;
 using BBT.Aether.AspNetCore.Tracing;
 using BBT.Aether.Users;

--- a/framework/src/BBT.Aether.Core/BBT/Aether/Pagination/HateoasPagedList.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/Pagination/HateoasPagedList.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace BBT.Aether.Domain.Repositories;
+namespace BBT.Aether;
 
 /// <summary>
 /// Represents a paged list optimized for HATEOAS responses.

--- a/framework/src/BBT.Aether.Core/BBT/Aether/Pagination/PagedList.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/Pagination/PagedList.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace BBT.Aether.Domain.Repositories;
+namespace BBT.Aether;
 
 /// <summary>
 /// Represents a paged list of items.

--- a/framework/src/BBT.Aether.Core/BBT/Aether/Pagination/PaginationLinks.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/Pagination/PaginationLinks.cs
@@ -1,4 +1,4 @@
-namespace BBT.Aether.Application.Dtos;
+namespace BBT.Aether;
 
 /// <summary>
 /// HATEOAS pagination links for API responses.


### PR DESCRIPTION
Pagination-related classes and interfaces were moved to more appropriate projects and namespaces for better separation of concerns. References and using statements were updated accordingly to reflect these changes.

## Summary by Sourcery

Refactor pagination types and link generation into more appropriate projects and namespaces.

Enhancements:
- Move HATEOAS pagination link generator interfaces and implementations into the ASP.NET Core layer and update dependency injection registrations.
- Relocate core pagination models (paged list types and pagination links) into the shared core namespace for reuse across application and domain layers.
- Adjust application service contracts and using directives to reference the new pagination namespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization: restructured pagination components within the framework architecture for improved code organization and maintainability. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->