### PR TITLE
Release v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,7 @@ deploy/ssh-password.txt
 deploy/github-api-key.txt
 deploy/_run_all_log.txt
 **/**/Logs/*.json
+
+
+# AI Documentations
+ai-docs/

--- a/framework/src/BBT.Aether.Aspects/BBT/Aether/Aspects/Uow/UnitOfWorkAttribute.cs
+++ b/framework/src/BBT.Aether.Aspects/BBT/Aether/Aspects/Uow/UnitOfWorkAttribute.cs
@@ -104,7 +104,7 @@ public class UnitOfWorkAttribute : AetherMethodInterceptionAspect
             throw;
         }
     }
-
+    
     private UnitOfWorkOptions CreateOptions()
     {
         var options = new UnitOfWorkOptions

--- a/framework/src/BBT.Aether.Core/BBT/Aether/Uow/ILocalTransactionEventEnqueuer.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/Uow/ILocalTransactionEventEnqueuer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using BBT.Aether.Events;
+
+namespace BBT.Aether.Uow;
+
+/// <summary>
+/// Interface for local transactions that support event enqueueing.
+/// Allows DbContext to push events directly into its owning local transaction,
+/// ensuring events are routed to the correct Unit of Work regardless of ambient context.
+/// </summary>
+public interface ILocalTransactionEventEnqueuer
+{
+    /// <summary>
+    /// Enqueues domain events that were collected by DbContext during SaveChanges.
+    /// Events pushed here will be dispatched when the owning Unit of Work commits.
+    /// </summary>
+    /// <param name="events">The events to enqueue</param>
+    void EnqueueEvents(IEnumerable<DomainEventEnvelope> events);
+}
+

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Uow/CompositeUnitOfWork.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Uow/CompositeUnitOfWork.cs
@@ -192,6 +192,7 @@ public sealed class CompositeUnitOfWork(
 
         try
         {
+            await SaveChangesAsync(cancellationToken);
             var strategy = domainEventOptions?.DispatchStrategy ?? DomainEventDispatchStrategy.AlwaysUseOutbox;
             
             if (strategy == DomainEventDispatchStrategy.AlwaysUseOutbox)


### PR DESCRIPTION
## Summary by Sourcery

Improve background job execution reliability and domain event routing by tightening unit-of-work boundaries and linking EF Core transactions directly to their owning DbContexts.

Bug Fixes:
- Ensure background jobs are only scheduled after their database records are fully committed by registering scheduling in a unit-of-work completion callback.
- Guarantee job execution runs within an explicit unit of work when triggered via the Dapr job execution bridge, including proper commit/rollback on success or failure.
- Prevent loss or misrouting of domain events when SaveChanges is called directly on AetherDbContext by routing events through a local transaction enqueuer tied to the owning unit of work.

Enhancements:
- Introduce a LocalEventEnqueuer hook on AetherDbContext and wire it from EfCoreTransactionSource so domain events are enqueued into the correct local transaction.
- Simplify job status update logic in JobDispatcher to rely on the surrounding unit of work instead of creating nested units of work.
- Trigger SaveChanges on all tracked contexts before composite unit of work commit to ensure consistent state before domain event dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved background job execution with enhanced transaction handling to ensure reliable job processing and event dispatching.
  * Refactored domain event routing to prioritize local transaction enqueueing, providing better control over event dispatch timing and order.
  * Streamlined unit-of-work management in job dispatchers for clearer transactional boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->