### PR TITLE
Remove redundant closing brace in ServiceScopeFactoryExtensions

### DIFF
--- a/framework/src/BBT.Aether.Core/BBT/Aether/DependencyInjection/ServiceScopeFactoryExtensions.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/DependencyInjection/ServiceScopeFactoryExtensions.cs
@@ -157,4 +157,3 @@ public static class ServiceScopeFactoryExtensions
         }
     }
 }
-}


### PR DESCRIPTION
Eliminated an extra closing brace at the end of ServiceScopeFactoryExtensions.cs to clean up the code structure.

## Summary by Sourcery

Enhancements:
- Clean up ServiceScopeFactoryExtensions by removing a redundant closing brace at the end of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed syntax error by removing an extraneous closing brace with no impact on functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->