### PR TITLE
fix(audit): swap ActorUserName/Username, fix empty values, respect user-set audit fields

### DIFF
--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/Interceptors/AuditInterceptor.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/Interceptors/AuditInterceptor.cs
@@ -22,6 +22,10 @@ public class AuditInterceptor(
     IClock clock)
     : SaveChangesInterceptor
 {
+    /// <summary>
+    /// Fallback value used for required audit user properties when current user is not available.
+    /// </summary>
+    private const string UnknownAuditUser = "System";
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
         SetAuditEntity(eventData.Context!);
@@ -123,24 +127,17 @@ public class AuditInterceptor(
     {
         if (entry.Entity is IHasCreatedAt)
         {
-            entry.Property("CreatedAt").CurrentValue = clock.UtcNow;
+            var createdAtProperty = entry.Property("CreatedAt");
+            if (createdAtProperty.CurrentValue == null)
+            {
+                createdAtProperty.CurrentValue = clock.UtcNow;
+            }
         }
 
         if (entry.Entity is ICreationAuditedObject)
         {
-            if (!currentUser.UserName.IsNullOrEmpty())
-            {
-                entry.Property("CreatedBy").CurrentValue = currentUser.UserName;
-            }
-            else
-            {
-                entry.Property("CreatedBy").CurrentValue = guidGenerator.Create().ToString("N");
-            }
-
-            if (!currentUser.ActorUserName.IsNullOrEmpty())
-            {
-                entry.Property("CreatedByBehalfOf").CurrentValue = currentUser.ActorUserName;
-            }
+            SetAuditProperty(entry, "CreatedBy", currentUser.ActorUserName);
+            SetAuditProperty(entry, "CreatedByBehalfOf", currentUser.UserName);
         }
     }
 
@@ -165,25 +162,36 @@ public class AuditInterceptor(
     {
         if (entry.Entity is IHasModifyTime)
         {
-            entry.Property("ModifiedAt").CurrentValue = clock.UtcNow;
+            var modifiedAtProperty = entry.Property("ModifiedAt");
+            if (modifiedAtProperty.CurrentValue == null)
+            {
+                modifiedAtProperty.CurrentValue = clock.UtcNow;
+            }
         }
 
         if (entry.Entity is IModifyAuditedObject)
         {
-            if (!currentUser.UserName.IsNullOrEmpty())
-            {
-                entry.Property("ModifiedBy").CurrentValue = currentUser.UserName;
-            }
-            else
-            {
-                //TODO: Warning! Should always come from currentuser
-                entry.Property("ModifiedBy").CurrentValue = guidGenerator.Create().ToString("N");
-            }
+            SetAuditProperty(entry, "ModifiedBy", currentUser.ActorUserName);
+            SetAuditProperty(entry, "ModifiedByBehalfOf", currentUser.UserName);
+        }
+    }
 
-            if (!currentUser.ActorUserName.IsNullOrEmpty())
-            {
-                entry.Property("ModifiedByBehalfOf").CurrentValue = currentUser.ActorUserName;
-            }
+    private void SetAuditProperty(EntityEntry entry, string propertyName, string? value)
+    {
+        var property = entry.Property(propertyName);
+        var current = property.CurrentValue as string;
+        if (!current.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        if (!value.IsNullOrEmpty())
+        {
+            property.CurrentValue = value;
+        }
+        else
+        {
+            property.CurrentValue = property.Metadata.IsNullable ? null : UnknownAuditUser;
         }
     }
 
@@ -191,19 +199,16 @@ public class AuditInterceptor(
     {
         if (entry.Entity is IHasDeletionTime)
         {
-            entry.Property("DeletedAt").CurrentValue = clock.UtcNow;
+            var deletedAtProperty = entry.Property("DeletedAt");
+            if (deletedAtProperty.CurrentValue == null)
+            {
+                deletedAtProperty.CurrentValue = clock.UtcNow;
+            }
         }
 
         if (entry.Entity is IDeletionAuditedObject)
         {
-            if (!currentUser.UserName.IsNullOrEmpty())
-            {
-                entry.Property("DeletedBy").CurrentValue = currentUser.UserName;
-            }
-            else
-            {
-                entry.Property("DeletedBy").CurrentValue = guidGenerator.Create().ToString("N");
-            }
+            SetAuditProperty(entry, "DeletedBy", currentUser.ActorUserName);
         }
     }
 


### PR DESCRIPTION
## Summary

Implements audit interceptor changes for #45 and adds respect for caller-set values.

## Changes

- **Swap audit user sources:** `CreatedBy`/`ModifiedBy` use `ActorUserName`; `CreatedByBehalfOf`/`ModifiedByBehalfOf` use `UserName`.
- **Empty-value handling:** No random GUID; use `null` for nullable audit properties, `"System"` for required when current user value is empty.
- **Do not overwrite user-set values:** If the caller has already set an audit property or timestamp (`CreatedAt`, `ModifiedAt`, `DeletedAt`, `CreatedBy`, etc.), the interceptor leaves it unchanged.
- **Deletion audit:** `SetDeletionAuditProperties` uses `SetAuditProperty` and `ActorUserName` for `DeletedBy` with the same empty-value and no-overwrite behavior.

Refs #45

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Adjust audit interceptor behavior for creation, modification, and deletion metadata to respect caller-provided values and updated user identity sources.

Bug Fixes:
- Prevent overwriting pre-populated CreatedAt, ModifiedAt, and DeletedAt audit timestamps when they are already set.
- Avoid generating random GUIDs for audit user fields when the current user is unavailable, using null or a fallback value instead.
- Correct the mapping of user identity fields so Created*/Modified*/Deleted* properties use ActorUserName while *BehalfOf properties use UserName.
- Ensure deletion audit properties follow the same user resolution and non-overwrite rules as creation and modification.

Enhancements:
- Introduce a shared helper for setting audit user properties with consistent null/empty handling and a standard fallback for required fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved audit logging system with enhanced handling of user attribution, including a fallback mechanism for cases where user information is unavailable.
  * Consolidated audit property assignment logic to ensure consistent null/empty value handling across creation, modification, and deletion audit records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->