### PR TITLE
fix(background-jobs): normalize DateTime via EF Core ValueConverter and simplify job store API

### DIFF
--- a/framework/src/BBT.Aether.Aspects/BBT/Aether/Aspects/Uow/UnitOfWorkAspectProvider.cs
+++ b/framework/src/BBT.Aether.Aspects/BBT/Aether/Aspects/Uow/UnitOfWorkAspectProvider.cs
@@ -21,7 +21,7 @@ public class UnitOfWorkAspectProvider : IAspectProvider
     /// </summary>
     private readonly static HashSet<string> MarkerInterfaceNames = new()
     {
-        "BBT.Aether.Application.IApplicationService"
+        //"BBT.Aether.Application.IApplicationService"
     };
 
     /// <summary>

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BackgroundJobInfo.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BackgroundJobInfo.cs
@@ -58,6 +58,8 @@ public class BackgroundJobInfo : FullAuditedEntity<Guid>, IHasExtraProperties
     /// </summary>
     public BackgroundJobStatus Status { get; set; } = BackgroundJobStatus.Scheduled;
 
+    public bool IsActive => Status == BackgroundJobStatus.Scheduled || Status == BackgroundJobStatus.Running;
+
     /// <summary>
     /// Gets or sets when the job was handled (completed or failed).
     /// </summary>

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
@@ -37,7 +37,7 @@ public interface IJobStore
     Task<BackgroundJobInfo?> GetAsync(Guid id, CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Retrieves active background job information by the job name to active (external scheduler identifier).
+    /// Retrieves active background job information by the job name (external scheduler identifier).
     /// </summary>
     /// <param name="jobName">The unique job name used by the external scheduler (e.g., "send-email-order-123").</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
@@ -37,7 +37,7 @@ public interface IJobStore
     Task<BackgroundJobInfo?> GetAsync(Guid id, CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Retrieves background job information by the job name (external scheduler identifier).
+    /// Retrieves active background job information by the job name to active (external scheduler identifier).
     /// </summary>
     /// <param name="jobName">The unique job name used by the external scheduler (e.g., "send-email-order-123").</param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
@@ -47,22 +47,6 @@ public interface IJobStore
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when jobName is null or empty.</exception>
     Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Retrieves background job information by the job name, optionally filtering by status.
-    /// </summary>
-    /// <param name="jobName">The unique job name used by the external scheduler (e.g., "send-email-order-123").</param>
-    /// <param name="status">
-    /// When provided, only returns the job if its current status matches this value.
-    /// When <c>null</c>, no status filter is applied (equivalent to <see cref="GetByJobNameAsync(string, CancellationToken)"/>).
-    /// </param>
-    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
-    /// <returns>
-    /// A task representing the asynchronous retrieval operation.
-    /// The result contains the job information if found with the matching status; otherwise, null.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown when jobName is null or empty.</exception>
-    Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, BackgroundJobStatus? status, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Retrieves a collection of background jobs by handler name.

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
@@ -47,6 +47,22 @@ public interface IJobStore
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when jobName is null or empty.</exception>
     Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves background job information by the job name, optionally filtering by status.
+    /// </summary>
+    /// <param name="jobName">The unique job name used by the external scheduler (e.g., "send-email-order-123").</param>
+    /// <param name="status">
+    /// When provided, only returns the job if its current status matches this value.
+    /// When <c>null</c>, no status filter is applied (equivalent to <see cref="GetByJobNameAsync(string, CancellationToken)"/>).
+    /// </param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// A task representing the asynchronous retrieval operation.
+    /// The result contains the job information if found with the matching status; otherwise, null.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when jobName is null or empty.</exception>
+    Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, BackgroundJobStatus? status, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Retrieves a collection of background jobs by handler name.

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobExecutionBridge.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobExecutionBridge.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using BBT.Aether.Domain.Entities;
 using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Events;
 using BBT.Aether.MultiSchema;
@@ -41,11 +42,13 @@ public sealed class DaprJobExecutionBridge(
             }
 
             var jobStore = scope.ServiceProvider.GetRequiredService<IJobStore>();
-            var jobInfo = await jobStore.GetByJobNameAsync(jobName, cancellationToken);
+            var jobInfo = await jobStore.GetByJobNameAsync(jobName, BackgroundJobStatus.Scheduled, cancellationToken);
 
             if (jobInfo == null)
             {
-                logger.LogError("Job with name '{JobName}' not found in store", jobName);
+                logger.LogWarning(
+                    "Job '{JobName}' not found in Scheduled state — it may have already been completed, failed, or cancelled",
+                    jobName);
                 return;
             }
 

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobExecutionBridge.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobExecutionBridge.cs
@@ -42,7 +42,7 @@ public sealed class DaprJobExecutionBridge(
             }
 
             var jobStore = scope.ServiceProvider.GetRequiredService<IJobStore>();
-            var jobInfo = await jobStore.GetByJobNameAsync(jobName, BackgroundJobStatus.Scheduled, cancellationToken);
+            var jobInfo = await jobStore.GetByJobNameAsync(jobName, cancellationToken);
 
             if (jobInfo == null)
             {

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobScheduler.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobScheduler.cs
@@ -51,6 +51,7 @@ public class DaprJobScheduler(
                 jobName: jobName, // Use jobName as the unique identifier in Dapr
                 schedule: daprSchedule,
                 payload: new ReadOnlyMemory<byte>(payloadBytes),
+                overwrite: true,
                 cancellationToken: cancellationToken);
         }
         catch (Exception ex)

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -77,6 +77,21 @@ public class EfCoreJobStore<TDbContext> : IJobStore
     }
 
     /// <inheritdoc/>
+    public async Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, BackgroundJobStatus? status, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(jobName))
+            throw new ArgumentNullException(nameof(jobName));
+
+        var query = _dbContext.BackgroundJobs.Where(j => j.JobName == jobName);
+        if (status.HasValue)
+        {
+            query = query.Where(j => j.Status == status.Value);
+        }
+
+        return await query.FirstOrDefaultAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<BackgroundJobInfo>> GetByHandlerNameAsync(string handlerName, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(handlerName))

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -36,13 +36,12 @@ public class EfCoreJobStore<TDbContext> : IJobStore
             throw new ArgumentNullException(nameof(jobInfo));
 
         // Check if job already exists
-        var existingJob = await _dbContext.BackgroundJobs
-            .FirstOrDefaultAsync(j => j.Id == jobInfo.Id, cancellationToken);
+        var existingJob = await GetByJobNameAsync(jobInfo.JobName, cancellationToken);
 
         if (existingJob != null)
         {
             // Update existing job
-            jobInfo.ModifiedAt  = DateTime.UtcNow;
+            jobInfo.ModifiedAt = DateTime.UtcNow;
             _dbContext.Entry(existingJob).CurrentValues.SetValues(jobInfo);
             existingJob.ExtraProperties = jobInfo.ExtraProperties;
             existingJob.Payload = jobInfo.Payload;
@@ -67,32 +66,21 @@ public class EfCoreJobStore<TDbContext> : IJobStore
     }
 
     /// <inheritdoc/>
-    public async Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, CancellationToken cancellationToken = default)
+    public async Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(jobName))
             throw new ArgumentNullException(nameof(jobName));
 
         return await _dbContext.BackgroundJobs
-            .FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken);
+            .FirstOrDefaultAsync(j => j.JobName == jobName
+                    && (j.Status == BackgroundJobStatus.Scheduled || j.Status == BackgroundJobStatus.Running),
+                cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task<BackgroundJobInfo?> GetByJobNameAsync(string jobName, BackgroundJobStatus? status, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(jobName))
-            throw new ArgumentNullException(nameof(jobName));
-
-        var query = _dbContext.BackgroundJobs.Where(j => j.JobName == jobName);
-        if (status.HasValue)
-        {
-            query = query.Where(j => j.Status == status.Value);
-        }
-
-        return await query.FirstOrDefaultAsync(cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<IEnumerable<BackgroundJobInfo>> GetByHandlerNameAsync(string handlerName, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<BackgroundJobInfo>> GetByHandlerNameAsync(string handlerName,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(handlerName))
             throw new ArgumentNullException(nameof(handlerName));
@@ -128,7 +116,7 @@ public class EfCoreJobStore<TDbContext> : IJobStore
             throw new InvalidOperationException($"Job with id '{id}' not found.");
 
         job.Status = status;
-        job.ModifiedAt  = DateTime.UtcNow;
+        job.ModifiedAt = DateTime.UtcNow;
         if (handledTime.HasValue)
         {
             job.HandledTime = handledTime.Value;
@@ -142,4 +130,3 @@ public class EfCoreJobStore<TDbContext> : IJobStore
         // SaveChanges removed - will be flushed by UoW Commit or calling code
     }
 }
-

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/JobDispatcher.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/JobDispatcher.cs
@@ -120,11 +120,11 @@ public class JobDispatcher(
 
     /// <summary>
     /// Checks if a job has already been processed (idempotency check).
-    /// Returns true if job is in Completed or Cancelled state.
+    /// Returns true if job is in Completed or Cancelled or Failed state.
     /// </summary>
     private bool IsJobAlreadyProcessed(BackgroundJobInfo jobInfo, Guid jobId, string handlerName)
     {
-        // If job is already completed or cancelled, skip reprocessing
+        // If job is already completed or cancelled or failed, skip reprocessing
         if (jobInfo.Status == BackgroundJobStatus.Completed)
         {
             logger.LogWarning(
@@ -137,6 +137,14 @@ public class JobDispatcher(
         {
             logger.LogWarning(
                 "Handler '{HandlerName}' for job id '{JobId}' was cancelled. Skipping reprocessing (idempotency).",
+                handlerName, jobId);
+            return true;
+        }
+        
+        if (jobInfo.Status == BackgroundJobStatus.Failed)
+        {
+            logger.LogWarning(
+                "Handler '{HandlerName}' for job id '{JobId}' was failed. Skipping reprocessing (idempotency).",
                 handlerName, jobId);
             return true;
         }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/AetherDbContext.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/AetherDbContext.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using BBT.Aether.Clock;
 using BBT.Aether.Domain.Entities;
 using BBT.Aether.Domain.EntityFrameworkCore.Modeling;
 using BBT.Aether.Events;
@@ -18,7 +19,8 @@ namespace BBT.Aether.Domain.EntityFrameworkCore;
 
 public abstract class AetherDbContext<TDbContext>(
     DbContextOptions<TDbContext> options,
-    IDomainEventSink? eventSink = null)
+    IDomainEventSink? eventSink = null,
+    IClock? clock = null)
     : DbContext(options)
     where TDbContext : DbContext
 {
@@ -120,7 +122,7 @@ public abstract class AetherDbContext<TDbContext>(
             return;
         }
 
-        modelBuilder.Entity<TEntity>().ConfigureByConvention();
+        modelBuilder.Entity<TEntity>().ConfigureByConvention(clock);
         ConfigureGlobalFilters<TEntity>(modelBuilder, mutableEntityType);
     }
 

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/DomainEventDispatcher.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/DomainEventDispatcher.cs
@@ -35,15 +35,23 @@ public class DomainEventDispatcher(
 
             if (useOutboxDirectly)
             {
-                logger.LogDebug("Writing domain event to outbox: {EventType} (Name: {EventName}, Version: {Version})",
-                    metadata.EventType.Name, metadata.EventName, metadata.Version);
+                try
+                {
+                    logger.LogDebug("Writing domain event to outbox: {EventType} (Name: {EventName}, Version: {Version})",
+                        metadata.EventType.Name, metadata.EventName, metadata.Version);
 
-                // Write directly to outbox within the transaction
-                await eventBus.PublishAsync(@event, metadata, 
-                    subject: EventSubjectExtractor.ExtractSubject(@event),
-                    useOutbox: true, cancellationToken);
+                    await eventBus.PublishAsync(@event, metadata, 
+                        subject: EventSubjectExtractor.ExtractSubject(@event),
+                        useOutbox: true, cancellationToken);
 
-                logger.LogDebug("Successfully wrote domain event to outbox: {EventType}", metadata.EventType.Name);
+                    logger.LogDebug("Successfully wrote domain event to outbox: {EventType}", metadata.EventType.Name);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex,
+                        "Failed to publish domain event to outbox: {EventType}. Continuing with remaining events",
+                        metadata.EventType.Name);
+                }
             }
             else
             {

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/Modeling/AetherEntityTypeBuilderExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/Modeling/AetherEntityTypeBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using BBT.Aether.Auditing;
+using BBT.Aether.Clock;
 using BBT.Aether.Domain.Entities;
 using BBT.Aether.Domain.Entities.Auditing;
 using BBT.Aether.Domain.EntityFrameworkCore.ValueComparers;
@@ -11,9 +12,9 @@ namespace BBT.Aether.Domain.EntityFrameworkCore.Modeling;
 
 public static class AetherEntityTypeBuilderExtensions
 {
-    public static void ConfigureByConvention(this EntityTypeBuilder b)
+    public static void ConfigureByConvention(this EntityTypeBuilder b, IClock? clock = null)
     {
-        b.TryConfigureDateTimeUtc();
+        b.TryConfigureDateTimeUtc(clock);
         b.TryConfigureConcurrencyStamp();
         b.TryConfigureSoftDelete();
         b.TryConfigureDeletionTime();
@@ -26,18 +27,29 @@ public static class AetherEntityTypeBuilderExtensions
         b.TryConfigureExtraProperties();
     }
 
-    public static void TryConfigureDateTimeUtc(this EntityTypeBuilder b)
+    public static void TryConfigureDateTimeUtc(this EntityTypeBuilder b, IClock? clock = null)
     {
+        ClockDateTimeValueConverter? dateTimeConverter = clock != null ? new ClockDateTimeValueConverter(clock) : null;
+        ClockDateTimeOffsetValueConverter? dateTimeOffsetConverter = clock != null ? new ClockDateTimeOffsetValueConverter(clock) : null;
+
         foreach (var property in b.Metadata.GetProperties())
         {
             if (property.ClrType == typeof(DateTime) || property.ClrType == typeof(DateTime?))
             {
                 property.SetColumnType("timestamp with time zone");
+                if (dateTimeConverter != null)
+                {
+                    property.SetValueConverter(dateTimeConverter);
+                }
             }
 
             if (property.ClrType == typeof(DateTimeOffset) || property.ClrType == typeof(DateTimeOffset?))
             {
                 property.SetColumnType("timestamp with time zone");
+                if (dateTimeOffsetConverter != null)
+                {
+                    property.SetValueConverter(dateTimeOffsetConverter);
+                }
             }
         }
     }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/ValueComparers/ClockDateTimeOffsetValueConverter.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/ValueComparers/ClockDateTimeOffsetValueConverter.cs
@@ -1,0 +1,16 @@
+using System;
+using BBT.Aether.Clock;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace BBT.Aether.Domain.EntityFrameworkCore.ValueComparers;
+
+/// <summary>
+/// Value converter that normalizes <see cref="DateTimeOffset"/> values through <see cref="IClock.NormalizeToUtc(DateTimeOffset)"/>
+/// on both the read and write paths, ensuring consistent UTC offset across all entity properties.
+/// </summary>
+public sealed class ClockDateTimeOffsetValueConverter(IClock clock)
+    : ValueConverter<DateTimeOffset, DateTimeOffset>(
+        v => clock.NormalizeToUtc(v),
+        v => clock.NormalizeToUtc(v))
+{
+}

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/ValueComparers/ClockDateTimeValueConverter.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/ValueComparers/ClockDateTimeValueConverter.cs
@@ -1,0 +1,16 @@
+using System;
+using BBT.Aether.Clock;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace BBT.Aether.Domain.EntityFrameworkCore.ValueComparers;
+
+/// <summary>
+/// Value converter that normalizes <see cref="DateTime"/> values through <see cref="IClock.NormalizeToUtc(DateTime)"/>
+/// on both the read and write paths, ensuring consistent UTC <see cref="DateTimeKind"/> across all entity properties.
+/// </summary>
+public sealed class ClockDateTimeValueConverter(IClock clock)
+    : ValueConverter<DateTime, DateTime>(
+        v => clock.NormalizeToUtc(v),
+        v => clock.NormalizeToUtc(v))
+{
+}


### PR DESCRIPTION
## Summary

- **EF Core DateTime normalization**: Added `ClockDateTimeValueConverter` and `ClockDateTimeOffsetValueConverter` backed by `IClock.NormalizeToUtc`, applied automatically to all `DateTime`/`DateTimeOffset` properties at model-build time via `ConfigureByConvention`.
- **Job store API simplification**: Removed the overloaded `GetByJobNameAsync(name, status)` and consolidated active-job filtering (`Scheduled | Running`) into the single `GetByJobNameAsync(name)` method. Introduced `IsActive` computed property on `BackgroundJobInfo`.
- **Upsert by job name**: `SaveOrUpdateAsync` now looks up existing jobs by `JobName` instead of `Id`, enabling correct upsert-by-name semantics.
- **Idempotency improvements**: Added `Failed` status to the idempotency guard in `JobDispatcher` so previously-failed jobs are not reprocessed.
- **Dapr overwrite**: Pass `overwrite: true` when scheduling Dapr jobs to allow rescheduling without conflicts.
- **UoW aspect**: Commented out `IApplicationService` marker in `UnitOfWorkAspectProvider` to prevent automatic UoW wrapping on all application services.

## Test plan

- [ ] Verify EF Core reads `DateTime`/`DateTimeOffset` columns with correct UTC kind after normalization
- [ ] Confirm that scheduling the same job twice upserts rather than duplicates
- [ ] Confirm that `Failed` jobs are skipped on re-dispatch
- [ ] Confirm that Dapr job rescheduling works without conflicts (`overwrite: true`)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Normalize DateTime handling via clock-based EF Core converters and refine background job processing semantics, including upsert-by-name behavior, active-job filtering, and more robust dispatch and scheduling.

New Features:
- Introduce clock-backed EF Core value converters for DateTime and DateTimeOffset to ensure consistent UTC normalization across entities.
- Add an IsActive convenience property on BackgroundJobInfo to represent scheduled or running jobs.

Bug Fixes:
- Ensure SaveAsync upserts background jobs by JobName instead of Id to avoid duplicate jobs for the same scheduler identifier.
- Treat Failed background jobs as already processed to prevent unintended re-dispatch.
- Filter GetByJobNameAsync to return only active jobs so dispatchers and schedulers do not operate on completed or cancelled entries.
- Allow Dapr job rescheduling without conflicts by enabling overwrite when scheduling jobs.
- Prevent failures when writing domain events to the outbox from aborting dispatch of remaining events by catching and logging publishing errors.

Enhancements:
- Propagate IClock into AetherDbContext model configuration so DateTime normalization is applied by convention during model building.
- Relax unit-of-work auto-wrapping by excluding IApplicationService as a marker interface for UoW aspects.
- Clarify Dapr job execution logging when a job cannot be found as scheduled, indicating it may already be completed, failed, or cancelled.
- Standardize DateTime column configuration with value converters applied conditionally based on clock availability.
- Tidy comments and XML documentation on job store APIs to reflect active job semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `IsActive` property to background job information.
  * Implemented automatic UTC date/time normalization for database entities.

* **Bug Fixes**
  * Failed background jobs are now treated as already processed to prevent reprocessing.
  * Dapr job scheduling now properly overwrites existing jobs with the same name.
  * Event dispatching with outbox now handles errors gracefully without propagating exceptions.
  * Missing background jobs now log as warnings instead of errors.

* **Documentation**
  * Clarified background job store behavior for retrieving active jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->