### PR TITLE
Add failure policy in dapr schedular

### DIFF
--- a/framework/src/BBT.Aether.AspNetCore/BBT.Aether.AspNetCore.csproj
+++ b/framework/src/BBT.Aether.AspNetCore/BBT.Aether.AspNetCore.csproj
@@ -29,7 +29,7 @@
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
-        <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />
+<!--        <PackageReference Include="OpenTelemetry.Exporter.Zipkin" />-->
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Process" />

--- a/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/IBackgroundJobService.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/IBackgroundJobService.cs
@@ -34,6 +34,7 @@ public interface IBackgroundJobService
         TPayload payload,
         string schedule,
         Dictionary<string, object>? metadata = null,
+        JobScheduleFailurePolicy? failurePolicyOptions = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/IJobScheduler.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/IJobScheduler.cs
@@ -26,6 +26,7 @@ public interface IJobScheduler
         string jobName,
         string schedule,
         ReadOnlyMemory<byte> payload,
+        JobScheduleFailurePolicy? failurePolicyOptions = null,
         CancellationToken cancellationToken = default);
     
     /// <summary>

--- a/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/JobScheduleFailurePolicy.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/JobScheduleFailurePolicy.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace BBT.Aether.BackgroundJob;
+
+public sealed class JobScheduleFailurePolicy
+{
+    public FailurePolicyType PolicyType { get; private init; }
+    public TimeSpan? Interval { get; private init; }
+    public uint? MaxRetries { get; private init; }
+
+    public static JobScheduleFailurePolicy Drop() =>
+        new() { PolicyType = FailurePolicyType.Drop };
+
+    public static JobScheduleFailurePolicy Constant(TimeSpan interval, uint? maxRetries = null) =>
+        new() { PolicyType = FailurePolicyType.Constant, Interval = interval, MaxRetries = maxRetries };
+}
+
+public enum FailurePolicyType { Drop, Constant }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobService.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobService.cs
@@ -43,6 +43,7 @@ public sealed class BackgroundJobService(
         TPayload payload,
         string schedule,
         Dictionary<string, object>? metadata = null,
+        JobScheduleFailurePolicy? failurePolicyOptions = null,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(handlerName))
@@ -116,7 +117,7 @@ public sealed class BackgroundJobService(
             // This prevents race condition where scheduler triggers before DB write completes
             uow.OnCompleted(async _ =>
             {
-                await jobScheduler.ScheduleAsync(handlerName, jobName, schedule, payloadBytes, cancellationToken);
+                await jobScheduler.ScheduleAsync(handlerName, jobName, schedule, payloadBytes, failurePolicyOptions, cancellationToken);
                 
                 logger.LogInformation(
                     "Successfully scheduled job handler '{HandlerName}' with job name '{JobName}'. Entity ID: {EntityId}",
@@ -125,10 +126,6 @@ public sealed class BackgroundJobService(
         
             // Commit transaction - OnCompleted handlers run after this completes
             await uow.CommitAsync(cancellationToken);
-
-            logger.LogInformation(
-                "Successfully enqueued job handler '{HandlerName}' with job name '{JobName}'. Entity ID: {EntityId}",
-                handlerName, jobName, jobId);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
             return jobId;
@@ -195,7 +192,7 @@ public sealed class BackgroundJobService(
             // Reschedule with new schedule
             var payloadBytes = eventSerializer.Serialize(envelope);
             await jobScheduler.ScheduleAsync(jobInfo.HandlerName, jobInfo.JobName, newSchedule, payloadBytes,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             // Save updated entity
             await jobStore.SaveAsync(jobInfo, cancellationToken);

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobScheduler.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Dapr/DaprJobScheduler.cs
@@ -28,6 +28,7 @@ public class DaprJobScheduler(
         string jobName,
         string schedule,
         ReadOnlyMemory<byte> payload,
+        JobScheduleFailurePolicy? failurePolicyOptions = null,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(handlerName))
@@ -57,6 +58,7 @@ public class DaprJobScheduler(
                 schedule: daprSchedule,
                 payload: new ReadOnlyMemory<byte>(payloadBytes),
                 overwrite: true,
+                failurePolicyOptions: MapFailurePolicy(failurePolicyOptions),
                 cancellationToken: cancellationToken);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
@@ -92,7 +94,7 @@ public class DaprJobScheduler(
         {
             var jobInfo = await daprJobsClient.GetJobAsync(jobName, cancellationToken);
             await daprJobsClient.DeleteJobAsync(jobName, cancellationToken);
-            await ScheduleAsync(handlerName, jobName, newSchedule, jobInfo.Payload, cancellationToken);
+            await ScheduleAsync(handlerName, jobName, newSchedule, jobInfo.Payload, cancellationToken: cancellationToken);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
         }
@@ -156,6 +158,16 @@ public class DaprJobScheduler(
             { "exception.message", ex.Message },
         }));
     }
+
+    private static IJobFailurePolicyOptions? MapFailurePolicy(JobScheduleFailurePolicy? policy) =>
+        policy switch
+        {
+            null => null,
+            { PolicyType: FailurePolicyType.Drop } => new JobFailurePolicyDropOptions(),
+            { PolicyType: FailurePolicyType.Constant, Interval: { } interval } =>
+                new JobFailurePolicyConstantOptions(interval) { MaxRetries = policy.MaxRetries },
+            _ => null
+        };
 
     /// <summary>
     /// Parses a schedule string into a DaprJobSchedule.


### PR DESCRIPTION
## Summary by Sourcery

Add configurable failure policies to background job scheduling and propagate them through the background job service and scheduler interfaces.

New Features:
- Introduce JobScheduleFailurePolicy and FailurePolicyType to represent drop and constant retry scheduling behaviors.
- Allow callers of IBackgroundJobService.EnqueueAsync and IJobScheduler.ScheduleAsync to specify an optional job failure policy when scheduling jobs.

Enhancements:
- Map JobScheduleFailurePolicy to Dapr job failure policy options in the DaprJobScheduler so that Dapr jobs honor the configured behavior.
- Simplify logging and parameter passing in background job update and scheduling flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Background job scheduling now supports configurable failure policies. Jobs can be configured to drop on failure or retry with customizable intervals and maximum retry attempts.

* **Chores**
  * Removed Zipkin exporter package reference from build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/burgan-tech/aether/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->