### PR TITLE
Update EfCoreJobStore to only modify mutable fields

### DIFF
--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -40,11 +40,17 @@ public class EfCoreJobStore<TDbContext> : IJobStore
 
         if (existingJob != null)
         {
-            // Update existing job
-            jobInfo.ModifiedAt = DateTime.UtcNow;
-            _dbContext.Entry(existingJob).CurrentValues.SetValues(jobInfo);
-            existingJob.ExtraProperties = jobInfo.ExtraProperties;
+            // Update mutable fields only — never touch the key (Id) or creation audit.
+            // Copying Id via SetValues onto a tracked entity throws:
+            // "The property 'BackgroundJobInfo.Id' is part of a key and so cannot be modified".
+            existingJob.ExpressionValue = jobInfo.ExpressionValue;
             existingJob.Payload = jobInfo.Payload;
+            existingJob.Status = jobInfo.Status;
+            existingJob.HandledTime = jobInfo.HandledTime;
+            existingJob.RetryCount = jobInfo.RetryCount;
+            existingJob.LastError = jobInfo.LastError;
+            existingJob.ExtraProperties = jobInfo.ExtraProperties;
+            existingJob.ModifiedAt = DateTime.UtcNow;
         }
         else
         {

--- a/framework/test/BBT.Aether.Infrastructure.Tests/BBT.Aether.Infrastructure.Tests.csproj
+++ b/framework/test/BBT.Aether.Infrastructure.Tests/BBT.Aether.Infrastructure.Tests.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/framework/test/BBT.Aether.Infrastructure.Tests/BBT/Aether/BackgroundJob/EfCoreJobStoreTests.cs
+++ b/framework/test/BBT.Aether.Infrastructure.Tests/BBT/Aether/BackgroundJob/EfCoreJobStoreTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Domain.EntityFrameworkCore.Modeling;
+using BBT.Aether.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Aether.BackgroundJob;
+
+public class EfCoreJobStoreTests
+{
+    private sealed class TestJobDbContext(DbContextOptions<TestJobDbContext> options)
+        : DbContext(options), IHasEfCoreBackgroundJobs
+    {
+        public DbSet<BackgroundJobInfo> BackgroundJobs { get; set; } = default!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ConfigureBackgroundJob();
+    }
+
+    private static TestJobDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<TestJobDbContext>()
+            .UseInMemoryDatabase($"jobs-{Guid.NewGuid()}")
+            .Options);
+
+    private static BackgroundJobInfo NewJob(Guid id, string jobName, BackgroundJobStatus status,
+        string expression, int payloadVersion) =>
+        new(id, "handler", jobName)
+        {
+            Status = status,
+            ExpressionValue = expression,
+            Payload = JsonDocument.Parse($"{{\"v\":{payloadVersion}}}").RootElement
+        };
+
+    /// <summary>
+    /// Regression: a re-enqueue for the same JobName produces a NEW Guid. The update path must
+    /// copy mutable fields onto the existing tracked entity WITHOUT touching its key, otherwise
+    /// EF throws "The property 'BackgroundJobInfo.Id' is part of a key and so cannot be modified".
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_WhenJobWithSameNameExists_UpdatesMutableFieldsAndPreservesKey()
+    {
+        await using var db = NewContext();
+
+        var existingId = Guid.NewGuid();
+        db.BackgroundJobs.Add(NewJob(existingId, "job-1", BackgroundJobStatus.Scheduled, "old", 1));
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear(); // simulate a fresh request scope / load
+
+        var store = new EfCoreJobStore<TestJobDbContext>(db);
+
+        // Re-enqueue with a DIFFERENT Guid but the SAME JobName (the original failure scenario).
+        var incoming = NewJob(Guid.NewGuid(), "job-1", BackgroundJobStatus.Running, "new", 2);
+
+        await store.SaveAsync(incoming);
+        await Should.NotThrowAsync(db.SaveChangesAsync()); // previously threw on key modification
+
+        var rows = await db.BackgroundJobs.ToListAsync();
+        var row = rows.ShouldHaveSingleItem();
+        row.Id.ShouldBe(existingId); // key preserved, not overwritten by incoming.Id
+        row.Status.ShouldBe(BackgroundJobStatus.Running);
+        row.ExpressionValue.ShouldBe("new");
+        row.ModifiedAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenNoExistingJob_InsertsNewRow()
+    {
+        await using var db = NewContext();
+        var store = new EfCoreJobStore<TestJobDbContext>(db);
+
+        var id = Guid.NewGuid();
+        await store.SaveAsync(NewJob(id, "job-new", BackgroundJobStatus.Scheduled, "expr", 1));
+        await db.SaveChangesAsync();
+
+        var row = (await db.BackgroundJobs.ToListAsync()).ShouldHaveSingleItem();
+        row.Id.ShouldBe(id);
+        row.JobName.ShouldBe("job-new");
+    }
+}


### PR DESCRIPTION
Avoid copying key/creation audit values onto a tracked entity by assigning mutable properties individually in EfCoreJobStore. This prevents EF Core errors like "The property 'BackgroundJobInfo.Id' is part of a key and so cannot be modified" when re-enqueuing a job with a different incoming Id. Also set ModifiedAt to UtcNow on updates. Added Microsoft.EntityFrameworkCore.InMemory test dependency and new EfCoreJobStoreTests verifying that SaveAsync preserves the original key while updating mutable fields, and that it inserts new rows when no existing job exists.

## Summary by Sourcery

Ensure EfCoreJobStore only updates mutable fields on existing jobs while preserving primary keys and creation audit data, and add tests to guard against EF Core key modification errors when re-enqueuing jobs.

Bug Fixes:
- Prevent EF Core key modification errors by avoiding updates to the BackgroundJobInfo key and creation audit fields when saving existing jobs.

Enhancements:
- Update EfCoreJobStore to explicitly set only mutable job fields and stamp ModifiedAt with the current UTC time on updates.

Build:
- Add Microsoft.EntityFrameworkCore.InMemory as a test dependency for EF-backed job store tests.

Tests:
- Add in-memory EF Core tests for EfCoreJobStore to verify that SaveAsync preserves the original key while updating mutable fields and inserts a new row when no existing job exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential issue where background job identifiers could be inadvertently overwritten during updates. The system now correctly preserves job keys while updating only changeable properties.

* **Tests**
  * Added test coverage for background job persistence, including scenarios for updating existing jobs and creating new ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->