### PR TITLE
v1.0.26

### DIFF
--- a/.github/workflows/check-sonar.yml
+++ b/.github/workflows/check-sonar.yml
@@ -22,6 +22,17 @@ jobs:
         with:
           dotnet-version: |
             10.0.2xx
+      # PostSharp weaves BBT.Aether.Aspects against the ASP.NET Core shared
+      # framework and requires the Microsoft.AspNetCore.App *runtime* matching
+      # the principal .NET runtime to be present on disk (it does not roll
+      # forward). Install the latest 10.0 ASP.NET Core runtime into the same
+      # location used by setup-dotnet.
+      - name: Install ASP.NET Core runtime (required by PostSharp weaving)
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
+          ./dotnet-install.ps1 -Runtime aspnetcore -Channel 10.0 -InstallDir "$env:DOTNET_ROOT"
+          dotnet --list-runtimes
       - name: Cache SonarQube Cloud packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -38,7 +38,20 @@ jobs:
       with:
         dotnet-version: |
           10.0.2xx
-    
+
+    # PostSharp weaves BBT.Aether.Aspects against the ASP.NET Core shared
+    # framework and requires the Microsoft.AspNetCore.App *runtime* matching
+    # the principal .NET runtime to be present on disk (it does not roll
+    # forward). The SDK band alone does not guarantee a matching patch, so
+    # install the latest 10.0 ASP.NET Core runtime into the same location.
+    - name: Install ASP.NET Core runtime (required by PostSharp weaving)
+      shell: bash
+      run: |
+        curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+        chmod +x dotnet-install.sh
+        ./dotnet-install.sh --runtime aspnetcore --channel 10.0 --install-dir "$DOTNET_ROOT"
+        dotnet --list-runtimes
+
     - name: Calculate version
       id: version
       run: |


### PR DESCRIPTION
## Summary by Sourcery

Ensure GitHub workflows install the required ASP.NET Core runtime for PostSharp weaving when running against .NET 10 SDK.

CI:
- Update publish-nuget workflow to install the matching ASP.NET Core 10.0 runtime alongside the .NET SDK.
- Update check-sonar workflow to install the matching ASP.NET Core 10.0 runtime to support PostSharp during analysis runs.