### PR TITLE
BackgroundJobService: support ambient UoW enqueue

### DIFF
--- a/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/IBackgroundJobService.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/BackgroundJob/IBackgroundJobService.cs
@@ -21,6 +21,23 @@ public interface IBackgroundJobService
     /// <param name="payload">The data payload to be passed to the job handler when executed.</param>
     /// <param name="schedule">The schedule expression defining when the job should be executed (e.g., cron expression).</param>
     /// <param name="metadata">Additional metadata associated with the job (optional).</param>
+    /// <param name="failurePolicyOptions">Retry/failure policy for the scheduled job (optional).</param>
+    /// <param name="useAmbientUnitOfWork">
+    /// When <c>true</c> AND an ambient unit of work is active, the job record is persisted into the
+    /// AMBIENT unit of work (no own RequiresNew UoW, no self-commit) and the actual scheduler call is
+    /// deferred to the ambient UoW's <c>OnCompleted</c> — so the job row commits atomically with the
+    /// caller's business transaction and the scheduler only fires after a successful commit. This
+    /// prevents nested-UoW / shared-DbContext collisions ("A second operation was started on this
+    /// context instance") and orphaned scheduled jobs on rollback. When <c>false</c> (default) or when
+    /// no ambient unit of work exists, the legacy self-contained RequiresNew behavior is used.
+    /// </param>
+    /// <param name="jobId">
+    /// Optional caller-supplied entity id for the created job. When provided, <c>BackgroundJobInfo.Id</c>
+    /// is set to this value (and it is the returned id), so the caller can generate one correlation id
+    /// up front and reuse it for its own tracking row — avoiding a placeholder/mismatch and keeping
+    /// cancellation-by-id reliable. When <c>null</c> (default) an id is generated internally. Ignored
+    /// when a job with the same name already exists (the existing id is kept).
+    /// </param>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
     /// <returns>
     /// A task representing the asynchronous enqueue operation.
@@ -35,6 +52,8 @@ public interface IBackgroundJobService
         string schedule,
         Dictionary<string, object>? metadata = null,
         JobScheduleFailurePolicy? failurePolicyOptions = null,
+        bool useAmbientUnitOfWork = false,
+        Guid? jobId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobService.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobService.cs
@@ -44,6 +44,8 @@ public sealed class BackgroundJobService(
         string schedule,
         Dictionary<string, object>? metadata = null,
         JobScheduleFailurePolicy? failurePolicyOptions = null,
+        bool useAmbientUnitOfWork = false,
+        Guid? jobId = null,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(handlerName))
@@ -71,9 +73,10 @@ public sealed class BackgroundJobService(
             "Enqueueing job handler '{HandlerName}' with job name '{JobName}' and schedule '{Schedule}'",
             handlerName, jobName, schedule);
 
-        // Create job entity
-        var jobId = guidGenerator.Create();
-        activity?.SetTag("job.id", jobId.ToString());
+        // Create job entity. A caller-supplied id (when present) lets the caller reuse a single
+        // correlation id for its own tracking row; otherwise generate one.
+        var effectiveJobId = jobId ?? guidGenerator.Create();
+        activity?.SetTag("job.id", effectiveJobId.ToString());
 
         // Convert metadata to nullable dictionary for ExtraPropertyDictionary
         var extraProperties = new ExtraPropertyDictionary();
@@ -94,7 +97,7 @@ public sealed class BackgroundJobService(
             DataContentType = "application/json"
         };
 
-        var jobInfo = new BackgroundJobInfo(jobId, handlerName, jobName)
+        var jobInfo = new BackgroundJobInfo(effectiveJobId, handlerName, jobName)
         {
             ExpressionValue = schedule,
             Payload = eventSerializer.SerializeToElement(envelope),
@@ -104,6 +107,42 @@ public sealed class BackgroundJobService(
 
         // Serialize envelope for scheduler
         var payloadBytes = eventSerializer.Serialize(envelope);
+
+        // Transactional enqueue: when the caller has an ambient unit of work and opts in, persist the
+        // job record INTO that ambient UoW (no own RequiresNew transaction, no self-commit) and defer
+        // the scheduler call to its OnCompleted. The job row then commits atomically with the caller's
+        // business transaction and the scheduler only fires after a successful commit — avoiding
+        // nested-UoW / shared-DbContext collisions ("A second operation was started on this context
+        // instance") and orphaned scheduled jobs on rollback.
+        if (useAmbientUnitOfWork && uowManager.Current is { } ambientUow)
+        {
+            await jobStore.SaveAsync(jobInfo, cancellationToken);
+
+            ambientUow.OnCompleted(async _ =>
+            {
+                try
+                {
+                    await jobScheduler.ScheduleAsync(
+                        handlerName, jobName, schedule, payloadBytes, failurePolicyOptions, cancellationToken);
+
+                    logger.LogInformation(
+                        "Successfully scheduled job handler '{HandlerName}' with job name '{JobName}'. Entity ID: {EntityId}",
+                        handlerName, jobName, effectiveJobId);
+                }
+                catch (Exception ex)
+                {
+                    // The business transaction is already committed but the scheduler call failed.
+                    // OnCompleted handler exceptions are swallowed by the UoW, so log loudly here —
+                    // recovery (re-enqueue of the pending job intent) is the caller's responsibility.
+                    logger.LogError(ex,
+                        "Failed to schedule job handler '{HandlerName}' with job name '{JobName}' after commit. Entity ID: {EntityId}",
+                        handlerName, jobName, effectiveJobId);
+                }
+            });
+
+            activity?.SetStatus(ActivityStatusCode.Ok);
+            return effectiveJobId;
+        }
 
         await using var uow = await uowManager.BeginAsync(
             options: new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew },
@@ -121,14 +160,14 @@ public sealed class BackgroundJobService(
                 
                 logger.LogInformation(
                     "Successfully scheduled job handler '{HandlerName}' with job name '{JobName}'. Entity ID: {EntityId}",
-                    handlerName, jobName, jobId);
+                    handlerName, jobName, effectiveJobId);
             });
         
             // Commit transaction - OnCompleted handlers run after this completes
             await uow.CommitAsync(cancellationToken);
 
             activity?.SetStatus(ActivityStatusCode.Ok);
-            return jobId;
+            return effectiveJobId;
         }
         catch (Exception ex)
         {

--- a/framework/test/BBT.Aether.Infrastructure.Tests/BBT/Aether/BackgroundJob/BackgroundJobServiceTransactionalEnqueueTests.cs
+++ b/framework/test/BBT.Aether.Infrastructure.Tests/BBT/Aether/BackgroundJob/BackgroundJobServiceTransactionalEnqueueTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Clock;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Domain.Repositories;
+using BBT.Aether.Events;
+using BBT.Aether.Guids;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Uow;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Aether.BackgroundJob;
+
+/// <summary>
+/// Tests the transactional (useAmbientUnitOfWork) enqueue path of <see cref="BackgroundJobService"/>:
+/// the job record is persisted into the ambient unit of work and the scheduler call is deferred to
+/// the ambient UoW's OnCompleted — never invoked inline / before commit.
+/// </summary>
+public class BackgroundJobServiceTransactionalEnqueueTests
+{
+    private readonly IJobStore _jobStore = Substitute.For<IJobStore>();
+    private readonly IJobScheduler _jobScheduler = Substitute.For<IJobScheduler>();
+    private readonly IUnitOfWorkManager _uowManager = Substitute.For<IUnitOfWorkManager>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly ICurrentSchema _currentSchema = Substitute.For<ICurrentSchema>();
+    private readonly IEventSerializer _eventSerializer = Substitute.For<IEventSerializer>();
+    private readonly BackgroundJobService _sut;
+
+    public BackgroundJobServiceTransactionalEnqueueTests()
+    {
+        _guidGenerator.Create().Returns(Guid.NewGuid());
+        _clock.UtcNow.Returns(DateTime.UtcNow);
+        _currentSchema.Name.Returns("runtime_test");
+        _eventSerializer.Serialize(Arg.Any<object>()).Returns(new byte[] { 1, 2, 3 });
+        _sut = new BackgroundJobService(
+            _jobStore, _jobScheduler, _uowManager, _guidGenerator, _clock,
+            _currentSchema, _eventSerializer,
+            Substitute.For<ILogger<BackgroundJobService>>());
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WithAmbientUoW_PersistsJobAndDefersScheduleToOnCompleted()
+    {
+        // Arrange — an ambient UoW is active; capture its OnCompleted handler.
+        var ambientUow = Substitute.For<IUnitOfWork>();
+        Func<IUnitOfWork, Task>? completed = null;
+        ambientUow.OnCompleted(Arg.Do<Func<IUnitOfWork, Task>>(h => completed = h));
+        _uowManager.Current.Returns(ambientUow);
+
+        // Act
+        var jobId = await _sut.EnqueueAsync(
+            "handler", "job-1", new { X = 1 }, "@every 5s",
+            metadata: null, failurePolicyOptions: null, useAmbientUnitOfWork: true,
+            cancellationToken: CancellationToken.None);
+
+        // Assert — job saved into the ambient UoW; NO own UoW opened, NO self-commit,
+        // and the scheduler has NOT been called yet (deferred).
+        jobId.ShouldNotBe(Guid.Empty);
+        await _jobStore.Received(1).SaveAsync(Arg.Any<BackgroundJobInfo>(), Arg.Any<CancellationToken>());
+        await _uowManager.DidNotReceive().BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>());
+        await ambientUow.DidNotReceive().CommitAsync(Arg.Any<CancellationToken>());
+        await _jobScheduler.DidNotReceiveWithAnyArgs().ScheduleAsync(default!, default!, default!, default);
+
+        // When the ambient UoW completes (post-commit), the scheduler fires.
+        completed.ShouldNotBeNull();
+        await completed!(ambientUow);
+        await _jobScheduler.Received(1).ScheduleAsync(
+            "handler", "job-1", "@every 5s", Arg.Any<ReadOnlyMemory<byte>>(),
+            Arg.Any<JobScheduleFailurePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WithSuppliedJobId_PersistsAndReturnsThatId()
+    {
+        // Arrange — ambient UoW so we hit the transactional path; capture the saved job entity.
+        var ambientUow = Substitute.For<IUnitOfWork>();
+        _uowManager.Current.Returns(ambientUow);
+        BackgroundJobInfo? saved = null;
+        await _jobStore.SaveAsync(Arg.Do<BackgroundJobInfo>(j => saved = j), Arg.Any<CancellationToken>());
+
+        var suppliedId = Guid.NewGuid();
+
+        // Act
+        var returnedId = await _sut.EnqueueAsync(
+            "handler", "job-3", new { X = 1 }, "@every 5s",
+            metadata: null, failurePolicyOptions: null, useAmbientUnitOfWork: true,
+            jobId: suppliedId, cancellationToken: CancellationToken.None);
+
+        // Assert — the caller-supplied id is used for the entity and returned.
+        returnedId.ShouldBe(suppliedId);
+        saved.ShouldNotBeNull();
+        saved!.Id.ShouldBe(suppliedId);
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_OptInButNoAmbientUoW_FallsBackToOwnRequiresNewUoW()
+    {
+        // Arrange — opt-in requested but NO ambient UoW → legacy self-contained path.
+        _uowManager.Current.Returns((IUnitOfWork?)null);
+        var ownUow = Substitute.For<IUnitOfWork>();
+        _uowManager.BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>()).Returns(ownUow);
+
+        // Act
+        await _sut.EnqueueAsync(
+            "handler", "job-2", new { X = 1 }, "@every 5s",
+            metadata: null, failurePolicyOptions: null, useAmbientUnitOfWork: true,
+            cancellationToken: CancellationToken.None);
+
+        // Assert — opened and committed its own UoW (legacy behavior preserved).
+        await _uowManager.Received(1).BeginAsync(Arg.Any<UnitOfWorkOptions>(), Arg.Any<CancellationToken>());
+        await ownUow.Received(1).CommitAsync(Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Adds transactional enqueue support that can persist the job record into an ambient unit-of-work and defer the scheduler call until the ambient UoW's OnCompleted. IBackgroundJobService now accepts two new optional parameters: useAmbientUnitOfWork (bool, default false) and jobId (Guid?). BackgroundJobService uses an effectiveJobId (caller-supplied or generated), saves the job into the ambient UoW when opted-in, attaches an OnCompleted handler to call the scheduler after commit (with logging and error handling), and falls back to the existing RequiresNew UoW path when no ambient UoW exists or opt-in is false. Also updates activity tags and return value to use the effective id. Adds unit tests (BackgroundJobServiceTransactionalEnqueueTests) covering persistence into ambient UoW, deferred scheduling, supplied job id usage, and fallback to legacy behavior.

## Summary by Sourcery

Add support for transactional background job enqueueing that can persist jobs into an ambient unit of work and defer scheduling until after commit.

New Features:
- Allow background jobs to be enqueued using the ambient unit of work, deferring scheduler invocation to the unit of work's completion.
- Support caller-supplied job IDs for enqueued background jobs to enable correlation with external tracking.

Tests:
- Add transactional enqueue unit tests covering ambient unit of work persistence, deferred scheduling, supplied job ID usage, and fallback to legacy behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background job enqueueing now supports deferring scheduler invocation until an active transaction completes
  * Added optional job ID parameter to allow callers to specify correlation-friendly identifiers for background jobs

* **Tests**
  * Added comprehensive test coverage for transactional job enqueueing scenarios with ambient transaction contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->