### PR TITLE
Add BBT.Aether.Npgsql  in publish.yml

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -155,7 +155,8 @@ jobs:
           "./framework/src/BBT.Aether.Abstractions/BBT.Aether.Abstractions.csproj"
           "./framework/src/BBT.Aether.Aspects/BBT.Aether.Aspects.csproj"
           "./framework/src/BBT.Aether.AutoMapper/BBT.Aether.AutoMapper.csproj"
-          "./framework/src/BBT.Aether.Mapperly/BBT.Aether.Mapperly.csproj"
+          "./framework/src/BBT.Aether.Mapperly/BBT.Aether.Mapperly.csproj",
+          "./framework/src/BBT.Aether.Npgsql/BBT.Aether.Npgsql.csproj"
         )
         
         # Check for module projects (if they exist)


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add BBT.Aether.Npgsql.csproj to the list of projects published by the GitHub Actions NuGet workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing an additional NuGet package during the release process, making the Npgsql package available alongside the existing package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->