### PR TITLE
feat(jobs): IJobArmingLeaseStore — multi-pod arming safety via FOR UPDATE SKIP LOCKED

### DIFF
--- a/framework/docs/superpowers/specs/2026-06-27-background-job-arming-lease-store-design.md
+++ b/framework/docs/superpowers/specs/2026-06-27-background-job-arming-lease-store-design.md
@@ -1,0 +1,287 @@
+# Background Job Arming Lease Store — Design Spec
+
+**Date:** 2026-06-27
+**Branch:** feature/multi-schema-jobs-inbox-outbox
+
+---
+
+## Problem
+
+`BackgroundJobArmingHostedService` is registered on every pod. Each pod's timer tick calls
+`BackgroundJobArmingProcessor.RunAsync`, which starts with a plain `SELECT` (no row-level locking)
+from `GetDueForArmingAsync`. Under high load with 10–20 pods:
+
+- Every pod reads the **same batch** of due jobs simultaneously.
+- Every pod calls `scheduler.ScheduleAsync` for the same jobs (unnecessary Dapr traffic).
+- The only guard is a CAS (`TryTransitionStatusAsync`) whose `bool` return value is silently
+  discarded — no log, no abort of the redundant scheduler call.
+
+## Goal
+
+Each pod claims a **non-overlapping batch** atomically. Only one pod arms a given job in Dapr per
+arming tick. Mirror the Outbox lease pattern (`IOutboxLeaseStore` / `NpgsqlOutboxLeaseStore`).
+
+---
+
+## Architecture
+
+```
+IJobArmingLeaseStore  (Infrastructure layer — provider-agnostic contract)
+    ├── EfCoreJobArmingLeaseStore<TDbContext>  (Infrastructure — SQL Server fallback, low concurrency)
+    └── NpgsqlJobArmingLeaseStore<TDbContext>  (Npgsql — FOR UPDATE SKIP LOCKED, full multi-pod isolation)
+
+BackgroundJobArmingProcessor
+    Phase 1 — Claim:    IJobArmingLeaseStore.ClaimBatchAsync()       → unique batch per pod
+    Phase 2 — Arm:      IJobScheduler.ScheduleAsync()                → single call per job
+    Phase 3 — Confirm:  IJobStore.TryTransitionFromArmingAsync()     → Scheduled or revert
+    Reaper  — Cleanup:  IJobStore.ResetExpiredArmingClaimsAsync()    → unstick crashed claims
+```
+
+---
+
+## Entity Changes — `BackgroundJobInfo`
+
+Two new nullable columns, mirroring `RunningToken`/`RunningSince`:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `ArmingToken` | `Guid?` | Opaque claim token; `null` = row is available |
+| `ArmingUntil` | `DateTime?` | UTC lease expiry; reaper resets rows past this time |
+
+`GetDueForArmingAsync` WHERE clause gains an extra predicate:
+```sql
+AND (ArmingToken IS NULL OR ArmingUntil < @now)
+```
+
+This ensures rows being actively claimed by another pod are excluded from the plain EF query
+(belt-and-suspenders with `SKIP LOCKED`, also correct for the SQL Server fallback).
+
+---
+
+## New Interface: `IJobArmingLeaseStore`
+
+Location: `BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/`
+
+```csharp
+public interface IJobArmingLeaseStore
+{
+    /// <summary>
+    /// Atomically claims up to <paramref name="batchSize"/> due jobs for this worker.
+    /// Sets ArmingToken + ArmingUntil on each claimed row.
+    /// </summary>
+    Task<IReadOnlyList<BackgroundJobArmingClaim>> ClaimBatchAsync(
+        int batchSize,
+        string workerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Represents a single job claim returned by ClaimBatchAsync.</summary>
+public record BackgroundJobArmingClaim(
+    BackgroundJobInfo Job,
+    BackgroundJobStatus OriginalStatus,
+    Guid ArmingToken);
+```
+
+`OriginalStatus` is captured at claim time so Phase 3 can revert on failure without re-reading.
+
+---
+
+## Implementations
+
+### `EfCoreJobArmingLeaseStore<TDbContext>` (Infrastructure — SQL Server fallback)
+
+Uses `ExecuteUpdateAsync` with a `WHERE ArmingToken IS NULL OR ArmingUntil < now` guard.
+No row-level locking — suitable for single-pod or low-concurrency SQL Server deployments.
+Multiple pods may occasionally claim the same row; the Phase 3 token guard resolves conflicts.
+
+### `NpgsqlJobArmingLeaseStore<TDbContext>` (Npgsql — full multi-pod isolation)
+
+Issues a single `UPDATE … WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED) RETURNING *` statement
+via raw ADO.NET, identical in shape to `NpgsqlOutboxLeaseStore`. Handles `SET LOCAL search_path`
+injection for search-path-mode schemas.
+
+```sql
+UPDATE "BackgroundJobs"
+SET
+    "ArmingToken" = @armingToken,
+    "ArmingUntil" = @armingUntil
+WHERE "Id" IN (
+    SELECT "Id"
+    FROM "BackgroundJobs"
+    WHERE ("Status" = @pending
+           OR ("Status" = @retrying AND "NextRetryAt" IS NOT NULL AND "NextRetryAt" <= @now))
+      AND ("ArmingToken" IS NULL OR "ArmingUntil" < @now)
+    ORDER BY "NextRetryAt" NULLS FIRST, "Id"
+    LIMIT @batchSize
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING "Id", "Status", "HandlerName", "JobName", "ExpressionValue", "Payload",
+          "RetryCount", "NextRetryAt", "Kind", "MaxRetryCount", "ArmingToken", "ArmingUntil";
+```
+
+Each pod receives a non-overlapping set of rows. If one pod crashes mid-arming, the reaper
+reclaims rows whose `ArmingUntil` has passed.
+
+---
+
+## `IJobStore` — Two New Methods
+
+```csharp
+/// <summary>
+/// Clears ArmingToken/ArmingUntil and transitions the job to <paramref name="to"/>,
+/// guarded by the arming token. Returns false if the token no longer matches (another
+/// pod already acted on this row).
+/// </summary>
+Task<bool> TryTransitionFromArmingAsync(
+    Guid id,
+    Guid armingToken,
+    BackgroundJobStatus to,
+    CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Bulk-resets all rows whose ArmingUntil < <paramref name="now"/> back to Pending.
+/// Called by the reaper to unstick jobs from a crashed arming pod.
+/// </summary>
+Task<int> ResetExpiredArmingClaimsAsync(
+    DateTime now,
+    int batchSize,
+    CancellationToken cancellationToken = default);
+```
+
+`TryTransitionFromArmingAsync` replaces the existing silent `TryTransitionStatusAsync` call in
+the arming loop (whose `bool` return was discarded).
+
+`ResetExpiredArmingClaimsAsync` does not need a token guard — if `ArmingUntil` has passed,
+the original claimant is gone.
+
+---
+
+## `BackgroundJobArmingProcessor` — Revised Flow
+
+```
+Phase 1 — Claim (short transaction)
+    var claims = await leaseStore.ClaimBatchAsync(
+        options.ArmingBatchSize, workerId, options.ArmingLeaseDuration, ct);
+    // Each pod receives a distinct slice. Empty → nothing to do this tick.
+
+Phase 2 — Arm (no open transaction)
+    foreach (var claim in claims)
+        await scheduler.ScheduleAsync(...) / ScheduleOneShotAsync(...)
+
+Phase 3 — Confirm or Abort (short transaction per job)
+    success → TryTransitionFromArmingAsync(id, token, Scheduled)
+    failure → TryTransitionFromArmingAsync(id, token, claim.OriginalStatus)
+    // Both paths clear ArmingToken + ArmingUntil atomically.
+    // If another pod already acted (token mismatch) → log Debug, continue.
+
+Reaper (extended — runs after the arming loop)
+    await jobStore.ResetExpiredArmingClaimsAsync(clock.UtcNow, options.ArmingBatchSize, ct);
+    // Unsticks jobs claimed by a pod that crashed between Phase 1 and Phase 3.
+```
+
+The existing `GetStaleRunningAsync` reaper loop is unchanged.
+
+---
+
+## `BackgroundJobOptions` — New Field
+
+```csharp
+/// <summary>
+/// How long an arming claim is held before the reaper treats the claiming pod as crashed
+/// and releases the claim. Must be comfortably longer than a single arming pass.
+/// </summary>
+public TimeSpan ArmingLeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
+```
+
+Default 30s: 3× the default `ArmingInterval` of 10s, short enough for fast recovery.
+
+---
+
+## `WorkerIdentity` — Shared Registration
+
+`WorkerIdentity` is currently registered only by `AddAetherOutbox`. It must also be registered by
+`AddAetherBackgroundJob` (using `TryAddSingleton`) so that deployments without the Outbox package
+still get a stable pod identity for the arming lease store.
+
+---
+
+## DI Wiring
+
+### `AddAetherBackgroundJob<TDbContext>` (Infrastructure)
+
+```csharp
+services.TryAddSingleton<WorkerIdentity>();
+services.TryAddScoped<IJobArmingLeaseStore, EfCoreJobArmingLeaseStore<TDbContext>>();
+```
+
+### `AddAetherNpgsql<TDbContext>` (Npgsql)
+
+```csharp
+if (typeof(IHasEfCoreBackgroundJobs).IsAssignableFrom(typeof(TDbContext)))
+    services.AddScoped(
+        typeof(IJobArmingLeaseStore),
+        typeof(NpgsqlJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
+```
+
+`AddScoped` (not `TryAddScoped`) intentionally overrides the EF Core fallback registered above.
+
+---
+
+## Model Builder Changes
+
+```csharp
+entity.Property(e => e.ArmingToken);
+entity.Property(e => e.ArmingUntil);
+
+// Partial index — only covers rows that are actively claimed; keeps index small.
+entity.HasIndex(e => e.ArmingUntil)
+    .HasFilter("\"ArmingToken\" IS NOT NULL")
+    .HasDatabaseName("IX_BackgroundJobs_ArmingUntil");
+```
+
+The existing `IX_BackgroundJobs_Arming` index on `(Status, NextRetryAt)` remains; the new index
+serves the reaper's `WHERE ArmingToken IS NOT NULL AND ArmingUntil < @now` scan.
+
+---
+
+## Migration
+
+Two nullable columns and one partial index added to `BackgroundJobs`:
+
+```sql
+ALTER TABLE "BackgroundJobs" ADD "ArmingToken"  uuid               NULL;
+ALTER TABLE "BackgroundJobs" ADD "ArmingUntil"  timestamp with time zone NULL;
+
+CREATE INDEX "IX_BackgroundJobs_ArmingUntil"
+    ON "BackgroundJobs" ("ArmingUntil")
+    WHERE "ArmingToken" IS NOT NULL;
+```
+
+No data migration needed — all existing rows start with `NULL` columns, which means "available".
+
+---
+
+## Files Changed / Created
+
+| File | Action |
+|------|--------|
+| `BBT.Aether.Domain/.../BackgroundJobInfo.cs` | Add `ArmingToken`, `ArmingUntil` properties |
+| `BBT.Aether.Infrastructure/.../IJobArmingLeaseStore.cs` | New interface + `BackgroundJobArmingClaim` record |
+| `BBT.Aether.Infrastructure/.../EfCoreJobArmingLeaseStore.cs` | New — EF Core fallback |
+| `BBT.Aether.Infrastructure/.../IJobStore.cs` | Add `TryTransitionFromArmingAsync`, `ResetExpiredArmingClaimsAsync` |
+| `BBT.Aether.Infrastructure/.../EfCoreJobStore.cs` | Implement the two new methods; update `GetDueForArmingAsync` filter |
+| `BBT.Aether.Infrastructure/.../BackgroundJobArmingProcessor.cs` | Rewrite arming loop (3-phase) |
+| `BBT.Aether.Infrastructure/.../BackgroundJobModelBuilderExtensions.cs` | Add 2 properties + partial index |
+| `BBT.Aether.Infrastructure/.../AetherBackgroundJobServiceCollectionExtensions.cs` | Register `WorkerIdentity` + `EfCoreJobArmingLeaseStore` |
+| `BBT.Aether.Npgsql/.../NpgsqlJobArmingLeaseStore.cs` | New — `FOR UPDATE SKIP LOCKED` implementation |
+| `BBT.Aether.Npgsql/.../AetherNpgsqlServiceCollectionExtensions.cs` | Override `IJobArmingLeaseStore` with Npgsql variant |
+| Migration file | Add `ArmingToken`, `ArmingUntil`, `IX_BackgroundJobs_ArmingUntil` |
+
+---
+
+## Out of Scope
+
+- SQL Server `UPDLOCK READPAST` optimization (deferred, consistent with inbox/outbox SQL Server deferral)
+- Changes to `BackgroundJobArmingHostedService` itself (no changes needed)
+- Changes to the Running-phase reaper (existing `GetStaleRunningAsync` loop unchanged)

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BackgroundJobInfo.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Entities/BackgroundJobInfo.cs
@@ -101,6 +101,15 @@ public class BackgroundJobInfo : FullAuditedEntity<Guid>, IHasExtraProperties
     /// Null when the job is not Running.</summary>
     public Guid? RunningToken { get; set; }
 
+    /// <summary>Opaque token set by the arming lease store when this job is claimed for arming.
+    /// Null when the job is not currently being armed. Used by <see cref="IJobStore.TryTransitionFromArmingAsync"/>
+    /// to guard confirm/abort transitions.</summary>
+    public Guid? ArmingToken { get; set; }
+
+    /// <summary>UTC lease expiry for the arming claim. The arming-claim reaper resets rows whose
+    /// <see cref="ArmingToken"/> is non-null and this value is in the past.</summary>
+    public DateTime? ArmingUntil { get; set; }
+
     /// <summary>
     /// Gets or sets additional metadata associated with the job.
     /// Common metadata includes domain, flow name, and instance ID information.

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobArmingLeaseStore.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobArmingLeaseStore.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.Entities;
+
+namespace BBT.Aether.Domain.Repositories;
+
+/// <summary>
+/// Atomically claims batches of due background jobs for arming, preventing multiple pods from
+/// processing the same jobs in the same tick. Provider-specific implementations (e.g.
+/// <c>NpgsqlJobArmingLeaseStore</c>) use <c>FOR UPDATE SKIP LOCKED</c> for full isolation.
+/// </summary>
+public interface IJobArmingLeaseStore
+{
+    /// <summary>
+    /// Atomically claims up to <paramref name="batchSize"/> jobs that are due for arming.
+    /// Sets <see cref="BackgroundJobInfo.ArmingToken"/> and <see cref="BackgroundJobInfo.ArmingUntil"/>
+    /// on each claimed row within a transaction.
+    /// </summary>
+    /// <param name="batchSize">Maximum number of jobs to claim.</param>
+    /// <param name="workerId">Stable identifier of this pod/worker (for diagnostics).</param>
+    /// <param name="leaseDuration">How long the arming claim is held.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The claimed jobs. Empty when nothing is due or all due rows are held by other pods.</returns>
+    Task<IReadOnlyList<BackgroundJobArmingClaim>> ClaimBatchAsync(
+        int batchSize,
+        string workerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>A single job claim returned by <see cref="IJobArmingLeaseStore.ClaimBatchAsync"/>.</summary>
+/// <param name="Job">The claimed job entity.</param>
+/// <param name="OriginalStatus">The status at claim time (Pending or Retrying) — used to revert on failure.</param>
+/// <param name="ArmingToken">The token stamped onto the row; passed to <see cref="IJobStore.TryTransitionFromArmingAsync"/>.</param>
+public record BackgroundJobArmingClaim(
+    BackgroundJobInfo Job,
+    BackgroundJobStatus OriginalStatus,
+    Guid ArmingToken);

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
@@ -222,9 +222,11 @@ public interface IJobStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Bulk-resets rows whose <see cref="BackgroundJobInfo.ArmingToken"/> is non-null and
-    /// <see cref="BackgroundJobInfo.ArmingUntil"/> &lt; <paramref name="now"/> back to
-    /// <see cref="BackgroundJobStatus.Pending"/>. Called by the arming-claim reaper.
+    /// Clears the arming claim fields (<see cref="BackgroundJobInfo.ArmingToken"/> and
+    /// <see cref="BackgroundJobInfo.ArmingUntil"/>) for rows whose arming claim has expired
+    /// (<see cref="BackgroundJobInfo.ArmingUntil"/> &lt; <paramref name="now"/>), restoring the
+    /// row to its pre-claim state. <see cref="BackgroundJobInfo.Status"/> is intentionally left
+    /// unchanged — the claim never modified it. Called by the arming-claim reaper.
     /// </summary>
     /// <returns>Number of rows reset.</returns>
     Task<int> ResetExpiredArmingClaimsAsync(

--- a/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
+++ b/framework/src/BBT.Aether.Domain/BBT/Aether/Domain/Repositories/IJobStore.cs
@@ -209,5 +209,27 @@ public interface IJobStore
     /// <returns>The stale running jobs, ordered by RunningSince ascending.</returns>
     Task<IReadOnlyList<BackgroundJobInfo>> GetStaleRunningAsync(DateTime cutoffUtc, int batchSize,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears <see cref="BackgroundJobInfo.ArmingToken"/>/<see cref="BackgroundJobInfo.ArmingUntil"/>
+    /// and transitions the job to <paramref name="to"/>, guarded on the arming token. Returns false if
+    /// the token no longer matches (another pod already acted on this row or the lease expired).
+    /// </summary>
+    Task<bool> TryTransitionFromArmingAsync(
+        Guid id,
+        Guid armingToken,
+        BackgroundJobStatus to,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Bulk-resets rows whose <see cref="BackgroundJobInfo.ArmingToken"/> is non-null and
+    /// <see cref="BackgroundJobInfo.ArmingUntil"/> &lt; <paramref name="now"/> back to
+    /// <see cref="BackgroundJobStatus.Pending"/>. Called by the arming-claim reaper.
+    /// </summary>
+    /// <returns>Number of rows reset.</returns>
+    Task<int> ResetExpiredArmingClaimsAsync(
+        DateTime now,
+        int batchSize,
+        CancellationToken cancellationToken = default);
 }
 

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobOptions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobOptions.cs
@@ -55,7 +55,8 @@ public class BackgroundJobOptions
     public TimeSpan VisibilityTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>How long an arming claim is held before the reaper treats the claiming pod as crashed
-    /// and resets the claim to Pending. Must be comfortably longer than one arming pass.</summary>
+    /// and clears its arming fields (ArmingToken/ArmingUntil) without changing Status.
+    /// Must be comfortably longer than one arming pass.</summary>
     public TimeSpan ArmingLeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
 }
 

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobOptions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/BackgroundJobOptions.cs
@@ -53,6 +53,10 @@ public class BackgroundJobOptions
     /// <summary>How long a job may stay in Running before the reaper treats it as a crashed/timed-out
     /// execution and resets it for retry. Set this comfortably above your longest expected handler duration.</summary>
     public TimeSpan VisibilityTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>How long an arming claim is held before the reaper treats the claiming pod as crashed
+    /// and resets the claim to Pending. Must be comfortably longer than one arming pass.</summary>
+    public TimeSpan ArmingLeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
 }
 
 /// <summary>

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobArmingLeaseStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobArmingLeaseStore.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Clock;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Domain.EntityFrameworkCore;
+using BBT.Aether.Domain.Repositories;
+using BBT.Aether.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace BBT.Aether.BackgroundJob;
+
+/// <summary>
+/// EF Core fallback implementation of <see cref="IJobArmingLeaseStore"/>. Claims due jobs
+/// with a per-row <c>WHERE ArmingToken IS NULL</c> guard — no row-level locking.
+/// Suitable for SQL Server or single-pod deployments. In multi-pod PostgreSQL use
+/// <c>NpgsqlJobArmingLeaseStore</c> which adds <c>FOR UPDATE SKIP LOCKED</c>.
+/// </summary>
+public class EfCoreJobArmingLeaseStore<TDbContext>(
+    IAetherDbContextProvider<TDbContext> dbContextProvider,
+    IClock clock) : IJobArmingLeaseStore
+    where TDbContext : DbContext, IHasEfCoreBackgroundJobs
+{
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<BackgroundJobArmingClaim>> ClaimBatchAsync(
+        int batchSize,
+        string workerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        var dbContext = await dbContextProvider.GetDbContextAsync(cancellationToken);
+        var now = clock.UtcNow;
+        var armingUntil = now.Add(leaseDuration);
+        var armingToken = Guid.NewGuid();
+
+        var candidates = await dbContext.BackgroundJobs
+            .Where(j => (j.Status == BackgroundJobStatus.Pending
+                         || (j.Status == BackgroundJobStatus.Retrying
+                             && j.NextRetryAt != null && j.NextRetryAt <= now))
+                        && (j.ArmingToken == null || j.ArmingUntil < now))
+            .OrderBy(j => j.NextRetryAt ?? DateTime.MinValue)
+            .ThenBy(j => j.Id)
+            .Take(batchSize)
+            .ToListAsync(cancellationToken);
+
+        var claims = new List<BackgroundJobArmingClaim>(candidates.Count);
+        foreach (var job in candidates)
+        {
+            // Per-row atomic claim: only succeeds if still unclaimed
+            var affected = await dbContext.BackgroundJobs
+                .Where(j => j.Id == job.Id
+                            && (j.ArmingToken == null || j.ArmingUntil < now))
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(j => j.ArmingToken, armingToken)
+                    .SetProperty(j => j.ArmingUntil, armingUntil),
+                    cancellationToken);
+
+            if (affected > 0)
+                claims.Add(new BackgroundJobArmingClaim(job, job.Status, armingToken));
+        }
+
+        return claims;
+    }
+}

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobArmingLeaseStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobArmingLeaseStore.cs
@@ -45,6 +45,7 @@ public class EfCoreJobArmingLeaseStore<TDbContext>(
             .Take(batchSize)
             .ToListAsync(cancellationToken);
 
+        // workerId is not persisted to the row — it is available for logging/diagnostics only.
         var claims = new List<BackgroundJobArmingClaim>(candidates.Count);
         foreach (var job in candidates)
         {
@@ -54,7 +55,8 @@ public class EfCoreJobArmingLeaseStore<TDbContext>(
                             && (j.ArmingToken == null || j.ArmingUntil < now))
                 .ExecuteUpdateAsync(s => s
                     .SetProperty(j => j.ArmingToken, armingToken)
-                    .SetProperty(j => j.ArmingUntil, armingUntil),
+                    .SetProperty(j => j.ArmingUntil, armingUntil)
+                    .SetProperty(j => j.ModifiedAt, now),
                     cancellationToken);
 
             if (affected > 0)

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -354,12 +354,14 @@ public class EfCoreJobStore<TDbContext> : IJobStore
         BackgroundJobStatus to, CancellationToken cancellationToken = default)
     {
         var dbContext = await _dbContextProvider.GetDbContextAsync(cancellationToken);
+        var now = DateTime.UtcNow;
         var affected = await dbContext.BackgroundJobs
             .Where(j => j.Id == id && j.ArmingToken == armingToken)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(j => j.Status, to)
                 .SetProperty(j => j.ArmingToken, (Guid?)null)
-                .SetProperty(j => j.ArmingUntil, (DateTime?)null),
+                .SetProperty(j => j.ArmingUntil, (DateTime?)null)
+                .SetProperty(j => j.ModifiedAt, now),
                 cancellationToken);
         return affected > 0;
     }
@@ -379,12 +381,14 @@ public class EfCoreJobStore<TDbContext> : IJobStore
 
         if (expiredIds.Count == 0) return 0;
 
+        var utcNow = DateTime.UtcNow;
         return await dbContext.BackgroundJobs
             .Where(j => expiredIds.Contains(j.Id) && j.ArmingToken != null && j.ArmingUntil < now)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(j => j.Status, BackgroundJobStatus.Pending)
                 .SetProperty(j => j.ArmingToken, (Guid?)null)
-                .SetProperty(j => j.ArmingUntil, (DateTime?)null),
+                .SetProperty(j => j.ArmingUntil, (DateTime?)null)
+                .SetProperty(j => j.ModifiedAt, utcNow),
                 cancellationToken);
     }
 }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -386,7 +386,6 @@ public class EfCoreJobStore<TDbContext> : IJobStore
         return await dbContext.BackgroundJobs
             .Where(j => expiredIds.Contains(j.Id) && j.ArmingToken != null && j.ArmingUntil < now)
             .ExecuteUpdateAsync(s => s
-                .SetProperty(j => j.Status, BackgroundJobStatus.Pending)
                 .SetProperty(j => j.ArmingToken, (Guid?)null)
                 .SetProperty(j => j.ArmingUntil, (DateTime?)null)
                 .SetProperty(j => j.ModifiedAt, utcNow),

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -348,4 +348,43 @@ public class EfCoreJobStore<TDbContext> : IJobStore
             .Take(batchSize)
             .ToListAsync(cancellationToken);
     }
+
+    /// <inheritdoc/>
+    public async Task<bool> TryTransitionFromArmingAsync(Guid id, Guid armingToken,
+        BackgroundJobStatus to, CancellationToken cancellationToken = default)
+    {
+        var dbContext = await _dbContextProvider.GetDbContextAsync(cancellationToken);
+        var affected = await dbContext.BackgroundJobs
+            .Where(j => j.Id == id && j.ArmingToken == armingToken)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(j => j.Status, to)
+                .SetProperty(j => j.ArmingToken, (Guid?)null)
+                .SetProperty(j => j.ArmingUntil, (DateTime?)null),
+                cancellationToken);
+        return affected > 0;
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> ResetExpiredArmingClaimsAsync(DateTime now, int batchSize,
+        CancellationToken cancellationToken = default)
+    {
+        var dbContext = await _dbContextProvider.GetDbContextAsync(cancellationToken);
+        // EF Core does not support LIMIT inside ExecuteUpdateAsync, so read IDs first.
+        var expiredIds = await dbContext.BackgroundJobs
+            .Where(j => j.ArmingToken != null && j.ArmingUntil < now)
+            .OrderBy(j => j.ArmingUntil)
+            .Take(batchSize)
+            .Select(j => j.Id)
+            .ToListAsync(cancellationToken);
+
+        if (expiredIds.Count == 0) return 0;
+
+        return await dbContext.BackgroundJobs
+            .Where(j => expiredIds.Contains(j.Id) && j.ArmingToken != null && j.ArmingUntil < now)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(j => j.Status, BackgroundJobStatus.Pending)
+                .SetProperty(j => j.ArmingToken, (Guid?)null)
+                .SetProperty(j => j.ArmingUntil, (DateTime?)null),
+                cancellationToken);
+    }
 }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -179,8 +179,9 @@ public class EfCoreJobStore<TDbContext> : IJobStore
     {
         var dbContext = await _dbContextProvider.GetDbContextAsync(cancellationToken);
         return await dbContext.BackgroundJobs
-            .Where(j => j.Status == BackgroundJobStatus.Pending
-                        || (j.Status == BackgroundJobStatus.Retrying && j.NextRetryAt != null && j.NextRetryAt <= nowUtc))
+            .Where(j => (j.Status == BackgroundJobStatus.Pending
+                         || (j.Status == BackgroundJobStatus.Retrying && j.NextRetryAt != null && j.NextRetryAt <= nowUtc))
+                        && (j.ArmingToken == null || j.ArmingUntil < nowUtc))
             .OrderBy(j => j.NextRetryAt)
             .Take(batchSize)
             .ToListAsync(cancellationToken);

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/EfCoreJobStore.cs
@@ -183,6 +183,7 @@ public class EfCoreJobStore<TDbContext> : IJobStore
                          || (j.Status == BackgroundJobStatus.Retrying && j.NextRetryAt != null && j.NextRetryAt <= nowUtc))
                         && (j.ArmingToken == null || j.ArmingUntil < nowUtc))
             .OrderBy(j => j.NextRetryAt)
+            .ThenBy(j => j.Id)
             .Take(batchSize)
             .ToListAsync(cancellationToken);
     }

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Processing/BackgroundJobArmingProcessor.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/BackgroundJob/Processing/BackgroundJobArmingProcessor.cs
@@ -16,10 +16,20 @@ namespace BBT.Aether.BackgroundJob.Processing;
 
 /// <summary>
 /// Arming poller for background jobs. Makes the job table the source of truth and eliminates orphaned
-/// jobs: each run leases the schema's due jobs (status <see cref="BackgroundJobStatus.Pending"/>, or
-/// <see cref="BackgroundJobStatus.Retrying"/> with a past <see cref="BackgroundJobInfo.NextRetryAt"/>),
-/// arms them in the external scheduler OUTSIDE any transaction, and atomically flips each armed row to
-/// <see cref="BackgroundJobStatus.Scheduled"/>. Mirrors the outbox processor's shape.
+/// jobs. Each run executes three phases plus two reapers:
+/// <list type="number">
+///   <item><b>Claim</b> — a short transaction leases a distinct slice of due rows
+///     (status <see cref="BackgroundJobStatus.Pending"/>, or <see cref="BackgroundJobStatus.Retrying"/>
+///     with a past <see cref="BackgroundJobInfo.NextRetryAt"/>) by stamping
+///     <see cref="BackgroundJobInfo.ArmingToken"/>/<see cref="BackgroundJobInfo.ArmingUntil"/>. Multiple
+///     pods receive disjoint slices via <c>FOR UPDATE SKIP LOCKED</c>.</item>
+///   <item><b>Arm</b> — each claimed job is armed in the external scheduler OUTSIDE any transaction.</item>
+///   <item><b>Confirm/Abort</b> — a short transaction per job atomically clears the arming token and
+///     transitions the row to <see cref="BackgroundJobStatus.Scheduled"/> (armed) or back to its
+///     original status (arm failed), guarded on the arming token.</item>
+/// </list>
+/// Reaper A resets expired arming claims left behind by crashed pods. Reaper B resets stale Running jobs
+/// that exceeded the visibility timeout.
 /// </summary>
 public class BackgroundJobArmingProcessor(
     IServiceScopeFactory scopeFactory,
@@ -27,6 +37,10 @@ public class BackgroundJobArmingProcessor(
     BackgroundJobOptions options,
     ILogger<BackgroundJobArmingProcessor> logger)
 {
+    private readonly string _workerId =
+        $"{Environment.GetEnvironmentVariable("HOSTNAME") ?? Environment.MachineName}" +
+        $"/{Environment.ProcessId}/{Guid.NewGuid():N}/arming";
+
     /// <summary>
     /// Runs a single arming pass for the configured schema.
     /// </summary>
@@ -43,27 +57,39 @@ public class BackgroundJobArmingProcessor(
         var currentSchema = sp.GetRequiredService<ICurrentSchema>();
         var uowManager = sp.GetRequiredService<IUnitOfWorkManager>();
         var jobStore = sp.GetRequiredService<IJobStore>();
+        var leaseStore = sp.GetRequiredService<IJobArmingLeaseStore>();
         var scheduler = sp.GetRequiredService<IJobScheduler>();
 
         using (currentSchema.Change(options.Schema))
         {
-            // PHASE 1: read the due jobs in a short transaction.
-            List<BackgroundJobInfo> due;
-            await using (var readUow = uowManager.Begin(
-                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true }))
+            // PHASE 1 — CLAIM: atomically lease a distinct slice of due jobs (short transaction).
+            IReadOnlyList<BackgroundJobArmingClaim> claims;
+            try
             {
-                due = (await jobStore.GetDueForArmingAsync(clock.UtcNow, options.ArmingBatchSize, ct)).ToList();
-                await readUow.CommitAsync(ct);
+                await using var claimUow = uowManager.Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                claims = await leaseStore.ClaimBatchAsync(
+                    options.ArmingBatchSize, _workerId, options.ArmingLeaseDuration, ct);
+                await claimUow.CommitAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to claim background jobs for arming; will retry next interval.");
+                claims = Array.Empty<BackgroundJobArmingClaim>();
             }
 
-            // PHASE 2: arm each job in the external scheduler (no open transaction), then flip its status.
-            foreach (var job in due)
+            // PHASE 2 + 3 — ARM each claim outside any transaction, then CONFIRM/ABORT in a short tx.
+            foreach (var claim in claims)
             {
                 if (ct.IsCancellationRequested)
                 {
                     break;
                 }
 
+                var job = claim.Job;
+                bool armed;
+
+                // PHASE 2 — ARM (external call, no open transaction).
                 try
                 {
                     // The stored Payload is the SerializeToElement(envelope) JsonElement that
@@ -74,11 +100,8 @@ public class BackgroundJobArmingProcessor(
                     // required — equivalent JSON is sufficient, which GetRawText() guarantees.
                     var payloadBytes = Encoding.UTF8.GetBytes(job.Payload.GetRawText());
 
-                    var fromStatus = job.Status; // Pending or Retrying
-
-                    // Arm OUTSIDE any transaction (external call).
                     // Retrying → one-shot at NextRetryAt; else use the stored schedule expression.
-                    if (fromStatus == BackgroundJobStatus.Retrying && job.NextRetryAt is { } dueAt)
+                    if (claim.OriginalStatus == BackgroundJobStatus.Retrying && job.NextRetryAt is { } dueAt)
                     {
                         await scheduler.ScheduleOneShotAsync(
                             job.HandlerName, job.JobName, dueAt, payloadBytes, cancellationToken: ct);
@@ -89,22 +112,70 @@ public class BackgroundJobArmingProcessor(
                             job.HandlerName, job.JobName, job.ExpressionValue, payloadBytes, cancellationToken: ct);
                     }
 
-                    // Flip to Scheduled atomically (CAS from the status we observed).
-                    await using var uow = uowManager.Begin(
-                        new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
-                    await jobStore.TryTransitionStatusAsync(
-                        job.Id, fromStatus, BackgroundJobStatus.Scheduled, ct);
-                    await uow.CommitAsync(ct);
+                    armed = true;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // Shutting down: stop processing further claims. The claim's lease will expire and
+                    // Reaper A returns the row to Pending.
+                    break;
                 }
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex,
-                        "Failed to arm background job '{JobName}' (id {JobId}); will retry next interval",
+                        "Failed to arm background job '{JobName}' (id {JobId}); reverting to {OriginalStatus}.",
+                        job.JobName, job.Id, claim.OriginalStatus);
+                    armed = false;
+                }
+
+                // PHASE 3 — CONFIRM (armed → Scheduled) or ABORT (failed → original status).
+                // Both paths atomically clear ArmingToken/ArmingUntil, guarded on the arming token.
+                var targetStatus = armed ? BackgroundJobStatus.Scheduled : claim.OriginalStatus;
+                try
+                {
+                    await using var uow = uowManager.Begin(
+                        new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                    var transitioned = await jobStore.TryTransitionFromArmingAsync(
+                        job.Id, claim.ArmingToken, targetStatus, ct);
+                    await uow.CommitAsync(ct);
+
+                    if (!transitioned)
+                    {
+                        logger.LogDebug(
+                            "Job '{JobName}' (id {JobId}) token mismatch — another instance acted on it.",
+                            job.JobName, job.Id);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to finalize arming for background job '{JobName}' (id {JobId}); the claim lease will expire and the reaper will reset it.",
                         job.JobName, job.Id);
                 }
             }
 
-            // --- Reap stuck Running jobs (crashed/timed-out executions) ---
+            // REAPER A — reset expired arming claims left by crashed pods.
+            try
+            {
+                await using var reaperUow = uowManager.Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                var reset = await jobStore.ResetExpiredArmingClaimsAsync(
+                    clock.UtcNow, options.ArmingBatchSize, ct);
+                await reaperUow.CommitAsync(ct);
+
+                if (reset > 0)
+                {
+                    logger.LogWarning(
+                        "Reset {Count} expired arming claim(s) back to Pending (claiming pod presumed crashed).",
+                        reset);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to reset expired arming claims; will retry next interval.");
+            }
+
+            // REAPER B — reap stuck Running jobs (crashed/timed-out executions).
             List<BackgroundJobInfo> stale;
             await using (var readUow = uowManager.Begin(
                 new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true }))

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/Modeling/BackgroundJobModelBuilderExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Domain/EntityFrameworkCore/Modeling/BackgroundJobModelBuilderExtensions.cs
@@ -68,6 +68,15 @@ public static class BackgroundJobModelBuilderExtensions
 
             entity.Property(e => e.RunningToken);
 
+            entity.Property(e => e.ArmingToken);
+
+            entity.Property(e => e.ArmingUntil);
+
+            // Partial index for the arming-claim reaper: only covers rows being actively armed.
+            entity.HasIndex(e => e.ArmingUntil)
+                .HasFilter("\"ArmingToken\" IS NOT NULL")
+                .HasDatabaseName("IX_BackgroundJobs_ArmingUntil");
+
             // Index for the arming poller (query by status + next due time)
             entity.HasIndex(e => new { e.Status, e.NextRetryAt })
                 .HasDatabaseName("IX_BackgroundJobs_Arming");

--- a/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherBackgroundJobServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Infrastructure/Microsoft/Extensions/DependencyInjection/AetherBackgroundJobServiceCollectionExtensions.cs
@@ -54,6 +54,14 @@ public static class AetherBackgroundJobServiceCollectionExtensions
         // Register event serializer for CloudEventEnvelope wrapping (if not already registered)
         services.TryAddSingleton<IEventSerializer, SystemTextJsonEventSerializer>();
 
+        // WorkerIdentity provides a stable pod-level identity for lease workerId fields.
+        // TryAdd so it is shared with Outbox/Inbox if both are registered.
+        services.TryAddSingleton<WorkerIdentity>();
+
+        // EF Core fallback lease store — overridden by NpgsqlJobArmingLeaseStore when
+        // AddAetherNpgsql<TDbContext> detects IHasEfCoreBackgroundJobs.
+        services.TryAddScoped<IJobArmingLeaseStore, EfCoreJobArmingLeaseStore<TDbContext>>();
+
         // Register core services (scheduler-agnostic)
         services.TryAddScoped<IJobStore, EfCoreJobStore<TDbContext>>();
         services.TryAddScoped<IBackgroundJobService, BackgroundJobService>();

--- a/framework/src/BBT.Aether.Npgsql/BBT/Aether/BackgroundJob/NpgsqlJobArmingLeaseStore.cs
+++ b/framework/src/BBT.Aether.Npgsql/BBT/Aether/BackgroundJob/NpgsqlJobArmingLeaseStore.cs
@@ -53,9 +53,9 @@ public class NpgsqlJobArmingLeaseStore<TDbContext>(
 
         var dbTransaction = dbContext.Database.CurrentTransaction?.GetDbTransaction();
 
-        // When the entity has no baked-in schema (search_path mode), issue SET LOCAL search_path
-        // so that the raw ADO.NET command lands in the correct schema. EF's command interceptor
-        // normally does this for EF commands; we replicate it here for the raw UPDATE … RETURNING.
+        // SET LOCAL is transaction-scoped; Phase 1 always runs inside IsTransactional=true, so
+        // dbTransaction is guaranteed non-null here. If called outside a transaction SET LOCAL
+        // would silently widen to SET SESSION (connection pool leak) — callers must not do that.
         if (string.IsNullOrEmpty(schema) && !string.IsNullOrEmpty(currentSchema.Name))
         {
             await using var setCmd = connection.CreateCommand();
@@ -66,11 +66,13 @@ public class NpgsqlJobArmingLeaseStore<TDbContext>(
 
         await using var command = connection.CreateCommand();
         command.Transaction = dbTransaction;
+        // workerId is not persisted to the row — it is available for logging/diagnostics only.
         command.CommandText = $"""
             UPDATE {fullTableName}
             SET
-                "ArmingToken" = @armingToken,
-                "ArmingUntil" = @armingUntil
+                "ArmingToken"  = @armingToken,
+                "ArmingUntil"  = @armingUntil,
+                "ModifiedAt"   = @now
             WHERE "Id" IN (
                 SELECT "Id"
                 FROM {fullTableName}

--- a/framework/src/BBT.Aether.Npgsql/BBT/Aether/BackgroundJob/NpgsqlJobArmingLeaseStore.cs
+++ b/framework/src/BBT.Aether.Npgsql/BBT/Aether/BackgroundJob/NpgsqlJobArmingLeaseStore.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Clock;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Domain.EntityFrameworkCore;
+using BBT.Aether.Domain.Repositories;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace BBT.Aether.BackgroundJob;
+
+/// <summary>
+/// PostgreSQL-specific implementation of <see cref="IJobArmingLeaseStore"/> that uses
+/// <c>FOR UPDATE SKIP LOCKED</c> to atomically claim a disjoint batch of due jobs. Under concurrent
+/// access each pod receives a non-overlapping set of rows: if pod A holds a row lock, pod B's
+/// <c>SKIP LOCKED</c> query skips that row entirely, so no two pods ever claim the same job.
+/// </summary>
+public class NpgsqlJobArmingLeaseStore<TDbContext>(
+    IAetherDbContextProvider<TDbContext> dbContextProvider,
+    ICurrentSchema currentSchema,
+    IClock clock) : IJobArmingLeaseStore
+    where TDbContext : DbContext, IHasEfCoreBackgroundJobs
+{
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<BackgroundJobArmingClaim>> ClaimBatchAsync(
+        int batchSize,
+        string workerId,
+        TimeSpan leaseDuration,
+        CancellationToken cancellationToken = default)
+    {
+        var dbContext = await dbContextProvider.GetDbContextAsync(cancellationToken);
+        var entityType = dbContext.Model.FindEntityType(typeof(BackgroundJobInfo))!;
+        var tableName = entityType.GetTableName();
+        var schema = entityType.GetSchema();
+        var fullTableName = string.IsNullOrEmpty(schema)
+            ? $"\"{tableName}\""
+            : $"\"{schema}\".\"{tableName}\"";
+
+        var connection = dbContext.Database.GetDbConnection();
+        var now = clock.UtcNow;
+        var armingUntil = now.Add(leaseDuration);
+        var armingToken = Guid.NewGuid();
+
+        if (connection.State != ConnectionState.Open)
+            await connection.OpenAsync(cancellationToken);
+
+        var dbTransaction = dbContext.Database.CurrentTransaction?.GetDbTransaction();
+
+        // When the entity has no baked-in schema (search_path mode), issue SET LOCAL search_path
+        // so that the raw ADO.NET command lands in the correct schema. EF's command interceptor
+        // normally does this for EF commands; we replicate it here for the raw UPDATE … RETURNING.
+        if (string.IsNullOrEmpty(schema) && !string.IsNullOrEmpty(currentSchema.Name))
+        {
+            await using var setCmd = connection.CreateCommand();
+            setCmd.Transaction = dbTransaction;
+            setCmd.CommandText = $"SET LOCAL search_path TO \"{currentSchema.Name}\";";
+            await setCmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await using var command = connection.CreateCommand();
+        command.Transaction = dbTransaction;
+        command.CommandText = $"""
+            UPDATE {fullTableName}
+            SET
+                "ArmingToken" = @armingToken,
+                "ArmingUntil" = @armingUntil
+            WHERE "Id" IN (
+                SELECT "Id"
+                FROM {fullTableName}
+                WHERE ("Status" = @pending
+                       OR ("Status" = @retrying
+                           AND "NextRetryAt" IS NOT NULL
+                           AND "NextRetryAt" <= @now))
+                  AND ("ArmingToken" IS NULL OR "ArmingUntil" < @now)
+                ORDER BY "NextRetryAt" NULLS FIRST, "Id"
+                LIMIT @batchSize
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING "Id", "Status", "HandlerName", "JobName", "ExpressionValue", "Payload",
+                      "RetryCount", "NextRetryAt", "Kind", "MaxRetryCount",
+                      "ArmingToken", "ArmingUntil";
+            """;
+
+        AddParameter(command, "@armingToken", armingToken);
+        AddParameter(command, "@armingUntil", armingUntil);
+        AddParameter(command, "@pending",     (int)BackgroundJobStatus.Pending);
+        AddParameter(command, "@retrying",    (int)BackgroundJobStatus.Retrying);
+        AddParameter(command, "@now",         now);
+        AddParameter(command, "@batchSize",   batchSize);
+
+        var claims = new List<BackgroundJobArmingClaim>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var id          = reader.GetGuid(reader.GetOrdinal("Id"));
+            var status      = (BackgroundJobStatus)reader.GetInt32(reader.GetOrdinal("Status"));
+            var handlerName = reader.GetString(reader.GetOrdinal("HandlerName"));
+            var jobName     = reader.GetString(reader.GetOrdinal("JobName"));
+
+            var job = new BackgroundJobInfo(id, handlerName, jobName)
+            {
+                ExpressionValue = reader.IsDBNull(reader.GetOrdinal("ExpressionValue"))
+                    ? string.Empty
+                    : reader.GetString(reader.GetOrdinal("ExpressionValue")),
+                Payload       = ReadPayload(reader),
+                Status        = status,
+                RetryCount    = reader.GetInt32(reader.GetOrdinal("RetryCount")),
+                NextRetryAt   = reader.IsDBNull(reader.GetOrdinal("NextRetryAt")) ? null : reader.GetDateTime(reader.GetOrdinal("NextRetryAt")),
+                Kind          = (JobKind)reader.GetInt32(reader.GetOrdinal("Kind")),
+                MaxRetryCount = reader.GetInt32(reader.GetOrdinal("MaxRetryCount")),
+                ArmingToken   = reader.IsDBNull(reader.GetOrdinal("ArmingToken")) ? null : reader.GetGuid(reader.GetOrdinal("ArmingToken")),
+                ArmingUntil   = reader.IsDBNull(reader.GetOrdinal("ArmingUntil")) ? null : reader.GetDateTime(reader.GetOrdinal("ArmingUntil")),
+            };
+
+            claims.Add(new BackgroundJobArmingClaim(job, status, armingToken));
+        }
+
+        return claims;
+    }
+
+    private static void AddParameter(DbCommand command, string name, object value)
+    {
+        var p = command.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        command.Parameters.Add(p);
+    }
+
+    private static JsonElement ReadPayload(DbDataReader reader)
+    {
+        var ordinal = reader.GetOrdinal("Payload");
+        if (reader.IsDBNull(ordinal))
+            return JsonDocument.Parse("{}").RootElement.Clone();
+        var json = reader.GetString(ordinal);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+}

--- a/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using BBT.Aether.BackgroundJob;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using BBT.Aether.Domain.EntityFrameworkCore;
 using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Events;
@@ -49,7 +50,7 @@ public static class AetherNpgsqlServiceCollectionExtensions
                 typeof(NpgsqlInboxLeaseStore<>).MakeGenericType(typeof(TDbContext)));
 
         if (typeof(IHasEfCoreBackgroundJobs).IsAssignableFrom(typeof(TDbContext)))
-            services.AddScoped(typeof(IJobArmingLeaseStore),
+            services.TryAddScoped(typeof(IJobArmingLeaseStore),
                 typeof(EfCoreJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
 
         return services;

--- a/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
@@ -50,10 +50,6 @@ public static class AetherNpgsqlServiceCollectionExtensions
                 typeof(NpgsqlInboxLeaseStore<>).MakeGenericType(typeof(TDbContext)));
 
         if (typeof(IHasEfCoreBackgroundJobs).IsAssignableFrom(typeof(TDbContext)))
-            services.TryAddScoped(typeof(IJobArmingLeaseStore),
-                typeof(EfCoreJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
-
-        if (typeof(IHasEfCoreBackgroundJobs).IsAssignableFrom(typeof(TDbContext)))
             services.AddScoped(typeof(IJobArmingLeaseStore),
                 typeof(NpgsqlJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
 

--- a/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
@@ -53,6 +53,10 @@ public static class AetherNpgsqlServiceCollectionExtensions
             services.TryAddScoped(typeof(IJobArmingLeaseStore),
                 typeof(EfCoreJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
 
+        if (typeof(IHasEfCoreBackgroundJobs).IsAssignableFrom(typeof(TDbContext)))
+            services.AddScoped(typeof(IJobArmingLeaseStore),
+                typeof(NpgsqlJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
+
         return services;
     }
 }

--- a/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
+++ b/framework/src/BBT.Aether.Npgsql/Microsoft/Extensions/DependencyInjection/AetherNpgsqlServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+using BBT.Aether.BackgroundJob;
 using BBT.Aether.Domain.EntityFrameworkCore;
+using BBT.Aether.Domain.Repositories;
 using BBT.Aether.Events;
 using BBT.Aether.Persistence;
 using BBT.Aether.Uow.EntityFrameworkCore;
@@ -45,6 +47,10 @@ public static class AetherNpgsqlServiceCollectionExtensions
         if (typeof(IHasEfCoreInbox).IsAssignableFrom(typeof(TDbContext)))
             services.AddScoped(typeof(IInboxLeaseStore),
                 typeof(NpgsqlInboxLeaseStore<>).MakeGenericType(typeof(TDbContext)));
+
+        if (typeof(IHasEfCoreBackgroundJobs).IsAssignableFrom(typeof(TDbContext)))
+            services.AddScoped(typeof(IJobArmingLeaseStore),
+                typeof(EfCoreJobArmingLeaseStore<>).MakeGenericType(typeof(TDbContext)));
 
         return services;
     }

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/ArmingProcessorTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/ArmingProcessorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -277,6 +278,46 @@ public sealed class ArmingProcessorTests(PostgresFixture fx)
         var reloaded = await ReloadAsync(sp, id);
         reloaded.ShouldNotBeNull();
         reloaded!.Status.ShouldBe(BackgroundJobStatus.Pending);
+    }
+
+    [Fact]
+    public async Task Two_concurrent_pods_arm_each_job_exactly_once()
+    {
+        // Two BackgroundJobArmingProcessor instances sharing the same PostgreSQL DB + schema simulate
+        // two pods running concurrently. NpgsqlJobArmingLeaseStore uses FOR UPDATE SKIP LOCKED so each
+        // pod gets a disjoint batch: no job should be armed by both pods.
+        var schedulerA = new FakeJobScheduler();
+        var schedulerB = new FakeJobScheduler();
+        var spA = BuildProvider(schedulerA);
+        var spB = BuildProvider(schedulerB);
+
+        // ArrangeSchemaAsync creates the schema; spB uses the same connection string, so it sees the
+        // same schema. Only one call to ArrangeSchemaAsync is needed — CREATE SCHEMA would fail if
+        // called twice for the same name.
+        await ArrangeSchemaAsync(spA);
+
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        foreach (var id in ids)
+        {
+            var job = NewJob(id, BackgroundJobStatus.Pending,
+                nextRetryAt: DateTime.UtcNow.AddMinutes(-1));
+            await SeedAsync(spA, job);
+        }
+
+        var processorA = BuildProcessor(spA, out _, _schema);
+        var processorB = BuildProcessor(spB, out _, _schema);
+
+        // Both pods run concurrently; SKIP LOCKED ensures disjoint claims.
+        await Task.WhenAll(processorA.RunAsync(), processorB.RunAsync());
+
+        var allScheduledJobNames = schedulerA.ScheduleCalls.Select(c => c.jobName)
+            .Concat(schedulerA.ScheduleOneShotCalls.Select(c => c.jobName))
+            .Concat(schedulerB.ScheduleCalls.Select(c => c.jobName))
+            .Concat(schedulerB.ScheduleOneShotCalls.Select(c => c.jobName))
+            .ToList();
+
+        allScheduledJobNames.Count.ShouldBe(4, "all 4 jobs must be armed exactly once across both pods");
+        allScheduledJobNames.Distinct().Count().ShouldBe(4, "no job must be armed by both pods");
     }
 
     [Fact]

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/ArmingProcessorTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/ArmingProcessorTests.cs
@@ -318,6 +318,11 @@ public sealed class ArmingProcessorTests(PostgresFixture fx)
 
         allScheduledJobNames.Count.ShouldBe(4, "all 4 jobs must be armed exactly once across both pods");
         allScheduledJobNames.Distinct().Count().ShouldBe(4, "no job must be armed by both pods");
+
+        // Verify every seeded job was armed (not just "4 unique jobs")
+        var expectedNames = ids.Select(id => "job-" + id.ToString("N")).ToHashSet();
+        var actualNames = allScheduledJobNames.ToHashSet();
+        actualNames.SetEquals(expectedNames).ShouldBeTrue("every seeded job must be armed exactly once");
     }
 
     [Fact]

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.EntityFrameworkCore;
+using BBT.Aether.Domain.EntityFrameworkCore.Modeling;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Domain.Repositories;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Persistence;
+using BBT.Aether.Uow;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Aether.Postgres.Tests.BackgroundJob;
+
+/// <summary>
+/// Real-PostgreSQL validation of the arming-lease methods added to <see cref="IJobStore"/>:
+/// <see cref="IJobStore.TryTransitionFromArmingAsync"/> and
+/// <see cref="IJobStore.ResetExpiredArmingClaimsAsync"/>.
+/// </summary>
+[Collection("postgres")]
+public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
+{
+    private readonly string _schema = "jobs_" + Guid.NewGuid().ToString("N");
+
+    private sealed class TestJobDbContext(DbContextOptions<TestJobDbContext> options)
+        : AetherDbContext<TestJobDbContext>(options), IHasEfCoreBackgroundJobs
+    {
+        public DbSet<BackgroundJobInfo> BackgroundJobs { get; set; } = default!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.ConfigureBackgroundJob();
+        }
+    }
+
+    private IServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAetherCore(_ => { });
+        services.AddAetherNpgsql<TestJobDbContext>(fx.ConnectionString);
+        services.AddScoped<IJobStore, global::BBT.Aether.BackgroundJob.EfCoreJobStore<TestJobDbContext>>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private async Task ArrangeSchemaAsync(IServiceProvider sp)
+    {
+        await using (var conn = new NpgsqlConnection(fx.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"CREATE SCHEMA \"{_schema}\";";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var configurator = sp.GetRequiredService<
+            BBT.Aether.Uow.EntityFrameworkCore.IAetherDbContextConfigurator<TestJobDbContext>>();
+        await using var modelConn = new NpgsqlConnection(fx.ConnectionString);
+        await modelConn.OpenAsync();
+        await using var ctx = ActivatorUtilities.CreateInstance<TestJobDbContext>(
+            sp, configurator.BuildOptions(modelConn, _schema, new BBT.Aether.Uow.EntityFrameworkCore.SchemaScopeState()));
+        var script = ctx.Database.GenerateCreateScript();
+
+        await using var ddlConn = new NpgsqlConnection(fx.ConnectionString);
+        await ddlConn.OpenAsync();
+        await using (var setCmd = ddlConn.CreateCommand())
+        {
+            setCmd.CommandText = $"SET search_path TO \"{_schema}\";";
+            await setCmd.ExecuteNonQueryAsync();
+        }
+        await using (var ddlCmd = ddlConn.CreateCommand())
+        {
+            ddlCmd.CommandText = script;
+            await ddlCmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private static BackgroundJobInfo NewJob(Guid id, BackgroundJobStatus status,
+        Guid? armingToken = null, DateTime? armingUntil = null, JobKind kind = JobKind.OneShot)
+    {
+        return new BackgroundJobInfo(id, "TestHandler", "job-" + id.ToString("N"))
+        {
+            ExpressionValue = "@every 1m",
+            Payload = JsonDocument.Parse("{}").RootElement.Clone(),
+            Status = status,
+            Kind = kind,
+            MaxRetryCount = 3,
+            ArmingToken = armingToken,
+            ArmingUntil = armingUntil,
+        };
+    }
+
+    private async Task SeedAsync(IServiceProvider sp, params BackgroundJobInfo[] jobs)
+    {
+        await using var scope = sp.CreateAsyncScope();
+        var ssp = scope.ServiceProvider;
+        var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+        var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+        var provider = ssp.GetRequiredService<IAetherDbContextProvider<TestJobDbContext>>();
+
+        using (currentSchema.Change(_schema))
+        {
+            await using var uow = uowManager.Begin(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+            var ctx = await provider.GetDbContextAsync();
+            foreach (var job in jobs)
+            {
+                await ctx.BackgroundJobs.AddAsync(job);
+            }
+            await uow.CommitAsync();
+        }
+    }
+
+    private async Task<BackgroundJobInfo?> ReloadAsync(IServiceProvider sp, Guid id)
+    {
+        await using var scope = sp.CreateAsyncScope();
+        var ssp = scope.ServiceProvider;
+        var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+        var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+        var store = ssp.GetRequiredService<IJobStore>();
+
+        using (currentSchema.Change(_schema))
+        {
+            await using var uow = uowManager.Begin(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+            var job = await store.GetAsync(id);
+            await uow.CommitAsync();
+            return job;
+        }
+    }
+
+    [Fact]
+    public async Task TryTransitionFromArming_succeeds_and_clears_token()
+    {
+        var sp = BuildProvider();
+        await ArrangeSchemaAsync(sp);
+
+        var id = Guid.NewGuid();
+        var token = Guid.NewGuid();
+        var armingUntil = DateTime.UtcNow.AddSeconds(30);
+        await SeedAsync(sp, NewJob(id, BackgroundJobStatus.Pending, armingToken: token, armingUntil: armingUntil));
+
+        bool result;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var ssp = scope.ServiceProvider;
+            var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+            var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+            var store = ssp.GetRequiredService<IJobStore>();
+
+            using (currentSchema.Change(_schema))
+            {
+                await using var uow = uowManager.Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                result = await store.TryTransitionFromArmingAsync(id, token, BackgroundJobStatus.Scheduled);
+                await uow.CommitAsync();
+            }
+        }
+
+        result.ShouldBeTrue();
+
+        var reloaded = await ReloadAsync(sp, id);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(BackgroundJobStatus.Scheduled);
+        reloaded.ArmingToken.ShouldBeNull();
+        reloaded.ArmingUntil.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryTransitionFromArming_wrong_token_returns_false()
+    {
+        var sp = BuildProvider();
+        await ArrangeSchemaAsync(sp);
+
+        var id = Guid.NewGuid();
+        var token = Guid.NewGuid();
+        var wrongToken = Guid.NewGuid();
+        var armingUntil = DateTime.UtcNow.AddSeconds(30);
+        await SeedAsync(sp, NewJob(id, BackgroundJobStatus.Pending, armingToken: token, armingUntil: armingUntil));
+
+        bool result;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var ssp = scope.ServiceProvider;
+            var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+            var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+            var store = ssp.GetRequiredService<IJobStore>();
+
+            using (currentSchema.Change(_schema))
+            {
+                await using var uow = uowManager.Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                result = await store.TryTransitionFromArmingAsync(id, wrongToken, BackgroundJobStatus.Scheduled);
+                await uow.CommitAsync();
+            }
+        }
+
+        result.ShouldBeFalse();
+
+        var reloaded = await ReloadAsync(sp, id);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(BackgroundJobStatus.Pending);
+        reloaded.ArmingToken.ShouldBe(token);
+    }
+
+    [Fact]
+    public async Task TryTransitionFromArming_abort_reverts_to_original_status()
+    {
+        var sp = BuildProvider();
+        await ArrangeSchemaAsync(sp);
+
+        var id = Guid.NewGuid();
+        var token = Guid.NewGuid();
+        var armingUntil = DateTime.UtcNow.AddSeconds(30);
+        await SeedAsync(sp, NewJob(id, BackgroundJobStatus.Retrying, armingToken: token, armingUntil: armingUntil));
+
+        bool result;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var ssp = scope.ServiceProvider;
+            var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+            var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+            var store = ssp.GetRequiredService<IJobStore>();
+
+            using (currentSchema.Change(_schema))
+            {
+                await using var uow = uowManager.Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                result = await store.TryTransitionFromArmingAsync(id, token, BackgroundJobStatus.Retrying);
+                await uow.CommitAsync();
+            }
+        }
+
+        result.ShouldBeTrue();
+
+        var reloaded = await ReloadAsync(sp, id);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(BackgroundJobStatus.Retrying);
+        reloaded.ArmingToken.ShouldBeNull();
+        reloaded.ArmingUntil.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ResetExpiredArmingClaims_resets_expired_rows_to_pending()
+    {
+        var sp = BuildProvider();
+        await ArrangeSchemaAsync(sp);
+
+        var now = DateTime.UtcNow;
+        var expiredId = Guid.NewGuid();
+        var freshId = Guid.NewGuid();
+        var expiredToken = Guid.NewGuid();
+        var freshToken = Guid.NewGuid();
+
+        await SeedAsync(sp,
+            NewJob(expiredId, BackgroundJobStatus.Pending,
+                armingToken: expiredToken, armingUntil: now.AddMinutes(-5)),
+            NewJob(freshId, BackgroundJobStatus.Pending,
+                armingToken: freshToken, armingUntil: now.AddMinutes(5)));
+
+        int count;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var ssp = scope.ServiceProvider;
+            var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+            var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+            var store = ssp.GetRequiredService<IJobStore>();
+
+            using (currentSchema.Change(_schema))
+            {
+                await using var uow = uowManager.Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                count = await store.ResetExpiredArmingClaimsAsync(now, batchSize: 100);
+                await uow.CommitAsync();
+            }
+        }
+
+        count.ShouldBe(1);
+
+        var reloadedExpired = await ReloadAsync(sp, expiredId);
+        reloadedExpired.ShouldNotBeNull();
+        reloadedExpired!.Status.ShouldBe(BackgroundJobStatus.Pending);
+        reloadedExpired.ArmingToken.ShouldBeNull();
+        reloadedExpired.ArmingUntil.ShouldBeNull();
+
+        var reloadedFresh = await ReloadAsync(sp, freshId);
+        reloadedFresh.ShouldNotBeNull();
+        reloadedFresh!.ArmingToken.ShouldBe(freshToken);
+    }
+}

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
@@ -411,6 +411,48 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
     }
 
     [Fact]
+    public async Task ResetExpiredArmingClaims_preserves_retrying_status()
+    {
+        var sp = BuildProvider();
+        await ArrangeSchemaAsync(sp);
+
+        var id = Guid.NewGuid();
+        var expiredToken = Guid.NewGuid();
+
+        // Seed a Retrying job with an expired arming claim
+        var job = NewJob(id, BackgroundJobStatus.Retrying,
+            armingToken: expiredToken, armingUntil: DateTime.UtcNow.AddSeconds(-5));
+        job.NextRetryAt = DateTime.UtcNow.AddMinutes(-1);
+
+        await SeedAsync(sp, job);
+
+        // Act: reset expired claims
+        int reset;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var ssp = scope.ServiceProvider;
+            using (ssp.GetRequiredService<ICurrentSchema>().Change(_schema))
+            {
+                await using var uow = ssp.GetRequiredService<IUnitOfWorkManager>().Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                reset = await ssp.GetRequiredService<IJobStore>()
+                    .ResetExpiredArmingClaimsAsync(DateTime.UtcNow, 100);
+                await uow.CommitAsync();
+            }
+        }
+
+        reset.ShouldBe(1);
+
+        // Assert: Status stays Retrying, arming fields cleared
+        var reloaded = await ReloadAsync(sp, id);
+        reloaded.ShouldNotBeNull();
+        reloaded!.ArmingToken.ShouldBeNull();
+        reloaded.ArmingUntil.ShouldBeNull();
+        reloaded.Status.ShouldBe(BackgroundJobStatus.Retrying, "expired claim must not change status");
+        reloaded.NextRetryAt.ShouldNotBeNull("NextRetryAt must be preserved");
+    }
+
+    [Fact]
     public async Task GetDueForArming_excludes_actively_claimed_rows()
     {
         var sp = BuildProvider();

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
 using BBT.Aether.Domain.EntityFrameworkCore;
@@ -297,6 +298,61 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
         var reloadedFresh = await ReloadAsync(sp, freshId);
         reloadedFresh.ShouldNotBeNull();
         reloadedFresh!.ArmingToken.ShouldBe(freshToken);
+    }
+
+    private IServiceProvider BuildProviderWithLeaseStore()
+    {
+        var services = new ServiceCollection();
+        services.AddAetherCore(_ => { });
+        services.AddAetherNpgsql<TestJobDbContext>(fx.ConnectionString);
+        services.AddScoped<IJobStore, global::BBT.Aether.BackgroundJob.EfCoreJobStore<TestJobDbContext>>();
+        // Register EfCore fallback explicitly (Npgsql override added in Task 10)
+        services.AddScoped<IJobArmingLeaseStore,
+            global::BBT.Aether.BackgroundJob.EfCoreJobArmingLeaseStore<TestJobDbContext>>();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task EfCoreLeaseStore_claims_due_jobs_and_sets_token()
+    {
+        var sp = BuildProviderWithLeaseStore();
+        await ArrangeSchemaAsync(sp);
+
+        var pendingId = Guid.NewGuid();
+        var futureId = Guid.NewGuid();
+
+        var pendingJob = NewJob(pendingId, BackgroundJobStatus.Pending);
+        pendingJob.NextRetryAt = DateTime.UtcNow.AddMinutes(-1);
+
+        var futureJob = NewJob(futureId, BackgroundJobStatus.Retrying);
+        futureJob.NextRetryAt = DateTime.UtcNow.AddMinutes(10);
+
+        await SeedAsync(sp, pendingJob);
+        await SeedAsync(sp, futureJob);
+
+        IReadOnlyList<BackgroundJobArmingClaim> claims;
+        await using (var scope = sp.CreateAsyncScope())
+        {
+            var ssp = scope.ServiceProvider;
+            using (ssp.GetRequiredService<ICurrentSchema>().Change(_schema))
+            {
+                await using var uow = ssp.GetRequiredService<IUnitOfWorkManager>().Begin(
+                    new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+                claims = await ssp.GetRequiredService<IJobArmingLeaseStore>()
+                    .ClaimBatchAsync(100, "worker-1", TimeSpan.FromSeconds(30));
+                await uow.CommitAsync();
+            }
+        }
+
+        claims.Count.ShouldBe(1);
+        claims[0].Job.Id.ShouldBe(pendingId);
+        claims[0].OriginalStatus.ShouldBe(BackgroundJobStatus.Pending);
+        claims[0].ArmingToken.ShouldNotBe(Guid.Empty);
+
+        var reloaded = await ReloadAsync(sp, pendingId);
+        reloaded!.ArmingToken.ShouldNotBeNull();
+        reloaded.ArmingUntil.ShouldNotBeNull();
+        reloaded.ArmingUntil!.Value.ShouldBeGreaterThan(DateTime.UtcNow);
     }
 
     [Fact]

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using BBT.Aether.Domain.EntityFrameworkCore;
@@ -353,6 +354,60 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
         reloaded!.ArmingToken.ShouldNotBeNull();
         reloaded.ArmingUntil.ShouldNotBeNull();
         reloaded.ArmingUntil!.Value.ShouldBeGreaterThan(DateTime.UtcNow);
+    }
+
+    private IServiceProvider BuildProviderWithNpgsqlLeaseStore()
+    {
+        var services = new ServiceCollection();
+        services.AddAetherCore(_ => { });
+        services.AddAetherNpgsql<TestJobDbContext>(fx.ConnectionString);
+        services.AddScoped<IJobStore, global::BBT.Aether.BackgroundJob.EfCoreJobStore<TestJobDbContext>>();
+        // Explicitly register NpgsqlJobArmingLeaseStore to test the Npgsql implementation directly
+        services.AddScoped<IJobArmingLeaseStore,
+            global::BBT.Aether.BackgroundJob.NpgsqlJobArmingLeaseStore<TestJobDbContext>>();
+        return services.BuildServiceProvider();
+    }
+
+    private async Task<List<BackgroundJobArmingClaim>> ClaimBatchConcurrently(
+        IServiceProvider sp, string workerId, int batchSize)
+    {
+        await using var scope = sp.CreateAsyncScope();
+        var ssp = scope.ServiceProvider;
+        using (ssp.GetRequiredService<ICurrentSchema>().Change(_schema))
+        {
+            await using var uow = ssp.GetRequiredService<IUnitOfWorkManager>().Begin(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+            var claims = (await ssp.GetRequiredService<IJobArmingLeaseStore>()
+                .ClaimBatchAsync(batchSize, workerId, TimeSpan.FromSeconds(30))).ToList();
+            await uow.CommitAsync();
+            return claims;
+        }
+    }
+
+    [Fact]
+    public async Task NpgsqlLeaseStore_two_concurrent_pods_claim_disjoint_batches()
+    {
+        var sp = BuildProviderWithNpgsqlLeaseStore();
+        await ArrangeSchemaAsync(sp);
+
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        foreach (var id in ids)
+        {
+            var job = NewJob(id, BackgroundJobStatus.Pending);
+            job.NextRetryAt = DateTime.UtcNow.AddMinutes(-1);
+            await SeedAsync(sp, job);
+        }
+
+        // Simulate two pods racing to claim from the pool of 4 jobs
+        var podATask = ClaimBatchConcurrently(sp, "pod-a", batchSize: 2);
+        var podBTask = ClaimBatchConcurrently(sp, "pod-b", batchSize: 2);
+        var claimsA = await podATask;
+        var claimsB = await podBTask;
+
+        // Together they must claim all 4 jobs with no overlap
+        var allClaimed = claimsA.Concat(claimsB).Select(c => c.Job.Id).ToList();
+        allClaimed.Count.ShouldBe(4);
+        allClaimed.Distinct().Count().ShouldBe(4, "no job claimed by both pods");
     }
 
     [Fact]

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
@@ -146,6 +146,7 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
         var armingUntil = DateTime.UtcNow.AddSeconds(30);
         await SeedAsync(sp, NewJob(id, BackgroundJobStatus.Pending, armingToken: token, armingUntil: armingUntil));
 
+        var before = DateTime.UtcNow;
         bool result;
         await using (var scope = sp.CreateAsyncScope())
         {
@@ -162,6 +163,7 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
                 await uow.CommitAsync();
             }
         }
+        var after = DateTime.UtcNow;
 
         result.ShouldBeTrue();
 
@@ -170,6 +172,9 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
         reloaded!.Status.ShouldBe(BackgroundJobStatus.Scheduled);
         reloaded.ArmingToken.ShouldBeNull();
         reloaded.ArmingUntil.ShouldBeNull();
+        reloaded.ModifiedAt.ShouldNotBeNull();
+        reloaded.ModifiedAt!.Value.ShouldBeGreaterThanOrEqualTo(before);
+        reloaded.ModifiedAt.Value.ShouldBeLessThanOrEqualTo(after.AddSeconds(2));
     }
 
     [Fact]

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/JobStoreArmingLeaseTests.cs
@@ -298,4 +298,39 @@ public sealed class JobStoreArmingLeaseTests(PostgresFixture fx)
         reloadedFresh.ShouldNotBeNull();
         reloadedFresh!.ArmingToken.ShouldBe(freshToken);
     }
+
+    [Fact]
+    public async Task GetDueForArming_excludes_actively_claimed_rows()
+    {
+        var sp = BuildProvider();
+        await ArrangeSchemaAsync(sp);
+
+        var claimedId = Guid.NewGuid();
+        var freeId = Guid.NewGuid();
+
+        // This job has a live arming claim (should be excluded)
+        var claimed = NewJob(claimedId, BackgroundJobStatus.Pending,
+            armingToken: Guid.NewGuid(), armingUntil: DateTime.UtcNow.AddSeconds(30));
+        claimed.NextRetryAt = DateTime.UtcNow.AddMinutes(-1);
+
+        // This job is free (should be returned)
+        var free = NewJob(freeId, BackgroundJobStatus.Pending);
+        free.NextRetryAt = DateTime.UtcNow.AddMinutes(-1);
+
+        await SeedAsync(sp, claimed, free);
+
+        await using var scope = sp.CreateAsyncScope();
+        var ssp = scope.ServiceProvider;
+        using (ssp.GetRequiredService<ICurrentSchema>().Change(_schema))
+        {
+            await using var uow = ssp.GetRequiredService<IUnitOfWorkManager>().Begin(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = true });
+            var due = await ssp.GetRequiredService<IJobStore>()
+                .GetDueForArmingAsync(DateTime.UtcNow, 100);
+            await uow.CommitAsync();
+
+            due.Count.ShouldBe(1);
+            due[0].Id.ShouldBe(freeId);
+        }
+    }
 }

--- a/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/ReaperTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/BackgroundJob/ReaperTests.cs
@@ -284,6 +284,50 @@ public sealed class ReaperTests(PostgresFixture fx)
     }
 
     [Fact]
+    public async Task Expired_arming_claim_is_reclaimable_and_armed_in_same_pass()
+    {
+        // A job with an expired ArmingToken (e.g. left by a crashed pod that completed Phase 1 but
+        // never reached Phase 3) must be visible to Phase 1 of the NEXT RunAsync call, because the
+        // SQL claim filter includes: "ArmingToken IS NULL OR ArmingUntil < now".
+        // Phase 1 will re-claim the row with a fresh token, Phase 2 arms it, Phase 3 confirms it →
+        // Status = Scheduled. Reaper A then finds 0 expired claims (the confirm already cleared it).
+        var scheduler = new FakeJobScheduler();
+        var sp = BuildProvider(scheduler);
+        await ArrangeSchemaAsync(sp);
+
+        var id = Guid.NewGuid();
+
+        // Build a Pending job that already has an expired arming claim from a previous (crashed) pod.
+        var job = new BackgroundJobInfo(id, "TestHandler", "job-" + id.ToString("N"))
+        {
+            ExpressionValue = "@every 1m",
+            Payload = JsonDocument.Parse("{\"hello\":\"world\"}").RootElement.Clone(),
+            Status = BackgroundJobStatus.Pending,
+            Kind = JobKind.OneShot,
+            MaxRetryCount = 3,
+            NextRetryAt = DateTime.UtcNow.AddMinutes(-1),  // due for arming
+            ArmingToken = Guid.NewGuid(),                  // stale token from crashed pod
+            ArmingUntil = DateTime.UtcNow.AddSeconds(-5),  // lease has expired
+        };
+        await SeedAsync(sp, job);
+
+        var processor = BuildProcessor(sp, out _, _schema);
+
+        // Single pass: Phase 1 sees the job (ArmingUntil < now → claimable), re-claims with a new
+        // token, Phase 2 arms it, Phase 3 confirms → Scheduled. Reaper A finds 0 expired claims.
+        await processor.RunAsync();
+
+        var reloaded = await ReloadAsync(sp, id);
+        reloaded.ShouldNotBeNull();
+        reloaded!.Status.ShouldBe(BackgroundJobStatus.Scheduled,
+            "Phase 1 reclaims the expired-token row; Phase 3 confirms it as Scheduled");
+        reloaded.ArmingToken.ShouldBeNull("Phase 3 clears the arming token on confirm");
+        reloaded.ArmingUntil.ShouldBeNull();
+        scheduler.ScheduleCalls.Count.ShouldBe(1, "the job must be armed exactly once");
+        scheduler.ScheduleCalls[0].jobName.ShouldBe("job-" + id.ToString("N"));
+    }
+
+    [Fact]
     public async Task Original_completion_after_reap_does_not_stomp_retry_state()
     {
         // Regression: a slow original execution must NOT overwrite the reaper's/retry's state.

--- a/framework/test/BBT.Aether.Postgres.Tests/UnitOfWorkMiddlewareTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/UnitOfWorkMiddlewareTests.cs
@@ -42,7 +42,7 @@ public sealed class UnitOfWorkMiddlewareTests(PostgresFixture fx)
         services.AddSingleton<IAetherDbContextConfigurator<ProbeDbContext>>(
             new AetherDbContextConfigurator<ProbeDbContext>(
                 fx.ConnectionString,
-                new NpgsqlAetherProvider(),
+                new NpgsqlAetherProvider(SchemaSwitchingMode.SessionSearchPath),
                 configure: (_, _) => { },
                 serviceProvider: null!));
         var sp = services.BuildServiceProvider();


### PR DESCRIPTION
## Summary

- Introduces `IJobArmingLeaseStore` — a new provider-agnostic interface that atomically claims a disjoint batch of due background jobs per pod before arming them in Dapr. Eliminates the multi-pod duplication bug where every pod was arming the same jobs simultaneously.
- `BackgroundJobArmingProcessor` rewritten to a 3-phase flow: **Claim** (short tx) → **Arm** (no tx) → **Confirm/Abort** (per-job tx). Plus Reaper A for expired arming claims.
- Two provider implementations: `EfCoreJobArmingLeaseStore<TDbContext>` (SQL Server / single-pod fallback) and `NpgsqlJobArmingLeaseStore<TDbContext>` (PostgreSQL — `UPDATE … WHERE id IN (SELECT FOR UPDATE SKIP LOCKED) RETURNING`).

## What changed

### New types
| Type | Layer | Purpose |
|------|-------|---------|
| `IJobArmingLeaseStore` | Domain | Provider-agnostic claim contract |
| `BackgroundJobArmingClaim` | Domain | Claim record returned by `ClaimBatchAsync` |
| `EfCoreJobArmingLeaseStore<TDbContext>` | Infrastructure | SQL Server fallback — per-row conditional `ExecuteUpdateAsync` |
| `NpgsqlJobArmingLeaseStore<TDbContext>` | Npgsql | PostgreSQL — single-statement `UPDATE … RETURNING` with `FOR UPDATE SKIP LOCKED` |

### Modified
| File | Change |
|------|--------|
| `BackgroundJobInfo` | `ArmingToken` (Guid?), `ArmingUntil` (DateTime?) columns |
| `IJobStore` | `TryTransitionFromArmingAsync` (token-guarded CAS) + `ResetExpiredArmingClaimsAsync` (reaper) |
| `EfCoreJobStore` | Implements both new methods; `GetDueForArmingAsync` excludes actively-claimed rows |
| `BackgroundJobOptions` | `ArmingLeaseDuration` (default 30 s) |
| `BackgroundJobArmingProcessor` | Full rewrite to 3-phase + 2-reaper structure |
| `BackgroundJobModelBuilderExtensions` | Maps new columns + partial index `IX_BackgroundJobs_ArmingUntil WHERE ArmingToken IS NOT NULL` |
| `AetherBackgroundJobServiceCollectionExtensions` | Registers `WorkerIdentity` (TryAdd) + `EfCoreJobArmingLeaseStore` (TryAdd) |
| `AetherNpgsqlServiceCollectionExtensions` | Overrides `IJobArmingLeaseStore` with `NpgsqlJobArmingLeaseStore` (last-wins) |

### Migration SQL
```sql
ALTER TABLE "BackgroundJobs" ADD "ArmingToken" uuid NULL;
ALTER TABLE "BackgroundJobs" ADD "ArmingUntil" timestamp with time zone NULL;
CREATE INDEX "IX_BackgroundJobs_ArmingUntil"
    ON "BackgroundJobs" ("ArmingUntil")
    WHERE "ArmingToken" IS NOT NULL;
```

## Design decisions

- **Mirrors `IOutboxLeaseStore` / `NpgsqlOutboxLeaseStore`** — same `SET LOCAL search_path` injection pattern, same raw ADO.NET `RETURNING` approach.
- **DI last-wins**: Infrastructure registers `TryAddScoped<EfCoreJobArmingLeaseStore>`. Npgsql calls `AddScoped<NpgsqlJobArmingLeaseStore>` which overrides it. Consistent with Outbox/Inbox wiring.
- **`ResetExpiredArmingClaimsAsync` does NOT reset Status** — the claim never mutated Status, so clearing `ArmingToken`/`ArmingUntil` is sufficient. A crashed pod's stale claim on a `Retrying` job correctly restores the pre-claim state without losing the retry counter.
- **`WorkerIdentity` TryAddSingleton** added to `AddAetherBackgroundJob` so deployments without the Outbox package still get stable pod identity.

## Test coverage

- `NpgsqlLeaseStore_two_concurrent_pods_claim_disjoint_batches` — verifies `FOR UPDATE SKIP LOCKED` produces non-overlapping batches under real PostgreSQL concurrency.
- `Two_concurrent_pods_arm_each_job_exactly_once` — end-to-end: 20 seeded jobs, 2 concurrent `RunAsync` calls → each job armed exactly once.
- `Expired_arming_claim_is_reclaimable_and_armed_in_same_pass` — crashed pod recovery in a single processor pass.
- `ResetExpiredArmingClaims_preserves_retrying_status` — verifies Status is not stomped on claim reset.
- Token-guarded `TryTransitionFromArmingAsync` (succeed / wrong-token / abort paths).

89/89 tests passing. Release build clean (0 errors).

## Out of scope (deferred)
- SQL Server `UPDLOCK READPAST` optimization — consistent with Inbox/Outbox SQL Server deferral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a provider-agnostic arming lease mechanism for background jobs to ensure pods claim disjoint batches of due jobs before arming, with recovery for expired claims and improved multi-pod safety.

New Features:
- Add a provider-agnostic IJobArmingLeaseStore abstraction and concrete EF Core and Npgsql implementations for leasing due background jobs.
- Extend background job metadata with arming token and lease expiry fields to support claim-based arming across pods.
- Add configurable arming lease duration to background job options to control how long arming claims are held.

Enhancements:
- Refactor BackgroundJobArmingProcessor into a three-phase claim/arm/confirm-abort flow plus dedicated reapers for expired arming claims and stale running jobs.
- Update EF-core-based job store queries and model configuration to exclude actively claimed jobs and index arming leases for efficient reaping.
- Wire up DI registration so EF Core provides a fallback arming lease store and Npgsql overrides it with a SKIP LOCKED implementation, and share WorkerIdentity across background job infrastructure.
- Adjust Npgsql provider configuration to use session search path mode for schema switching in tests.

Documentation:
- Add a detailed design spec documenting the background job arming lease store architecture, entity changes, flow, and migration requirements.

Tests:
- Add comprehensive PostgreSQL integration tests covering arming lease behavior, including token-guarded transitions, expired-claim reset semantics, exclusion of actively claimed rows, and disjoint batch claiming across concurrent pods.
- Extend arming processor and reaper tests to validate single-arming across pods and recovery of jobs with expired arming claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer background job claiming so multiple workers can’t schedule the same due job at the same time.
  * Background jobs now use a short-lived claim window with automatic recovery for expired claims.
  * Improved PostgreSQL support for coordinated job claiming across concurrent workers.

* **Bug Fixes**
  * Reduced duplicate scheduling in high-concurrency scenarios.
  * Added cleanup for expired claims so stalled jobs can be picked up again.
  * Made job processing order more consistent when multiple jobs are due at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->