### PR TITLE
Remove trailing comma in NuGet workflow

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -155,7 +155,7 @@ jobs:
           "./framework/src/BBT.Aether.Abstractions/BBT.Aether.Abstractions.csproj"
           "./framework/src/BBT.Aether.Aspects/BBT.Aether.Aspects.csproj"
           "./framework/src/BBT.Aether.AutoMapper/BBT.Aether.AutoMapper.csproj"
-          "./framework/src/BBT.Aether.Mapperly/BBT.Aether.Mapperly.csproj",
+          "./framework/src/BBT.Aether.Mapperly/BBT.Aether.Mapperly.csproj"
           "./framework/src/BBT.Aether.Npgsql/BBT.Aether.Npgsql.csproj"
         )
         


### PR DESCRIPTION
Remove a stray trailing comma from the project list in .github/workflows/publish-nuget.yml (BBT.Aether.Mapperly.csproj). This fixes the YAML list syntax and prevents potential CI parsing issues when publishing NuGet packages.

## Summary by Sourcery

CI:
- Remove an invalid trailing comma from the project list in the publish-nuget GitHub Actions workflow to ensure proper YAML parsing.