### PR TITLE
Add non-transactional event dispatch to outbox on commit

### DIFF
--- a/framework/src/BBT.Aether.Core/BBT/Aether/Events/AetherDomainEventOptions.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/Events/AetherDomainEventOptions.cs
@@ -30,5 +30,27 @@ public class AetherDomainEventOptions
     /// Default is AlwaysUseOutbox for maximum reliability.
     /// </summary>
     public DomainEventDispatchStrategy DispatchStrategy { get; set; } = DomainEventDispatchStrategy.AlwaysUseOutbox;
+
+    /// <summary>
+    /// Gets or sets whether a non-transactional unit of work (one with no shared database
+    /// transaction — e.g. a flow that persists via per-step <c>autoSave</c> rather than a single
+    /// enclosing transaction) also flushes its buffered domain events when it commits.
+    /// <para>
+    /// Default is <see langword="false"/> — the historical behavior: without a transaction the
+    /// unit of work cannot co-commit events atomically with the business data, so buffered events
+    /// are NOT dispatched and are effectively dropped. Callers that need events in such flows have
+    /// to publish them explicitly.
+    /// </para>
+    /// <para>
+    /// When set to <see langword="true"/>, on commit the unit of work dispatches its buffered
+    /// events using the configured <see cref="DispatchStrategy"/> even though no transaction was
+    /// opened. The business data has already been durably written by the per-step saves, so this
+    /// restores at-least-once delivery for these flows; it is NOT atomic with the business writes
+    /// (the event write is a separate durable write), so a crash between the two relies on the
+    /// consumer's idempotent retry/recovery. This is config-gated precisely so it can be disabled
+    /// at deploy time — without a code change — if it causes issues in production.
+    /// </para>
+    /// </summary>
+    public bool DispatchNonTransactionalEventsToOutbox { get; set; }
 }
 

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Uow/CompositeUnitOfWork.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Uow/CompositeUnitOfWork.cs
@@ -239,6 +239,12 @@ public sealed class CompositeUnitOfWork(
                     await CommitWithDirectPublishAsync(cancellationToken);
                 }
             }
+            else if ((domainEventOptions?.DispatchNonTransactionalEventsToOutbox ?? false)
+                     && _events.Count > 0
+                     && eventDispatcher is not null)
+            {
+                await CommitWithoutTransactionAsync(cancellationToken);
+            }
 
             IsCompleted = true;
             await InvokeCompletedHandlersAsync();
@@ -267,6 +273,30 @@ public sealed class CompositeUnitOfWork(
         }
 
         await _transaction!.CommitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Dispatches buffered domain events for a non-transactional unit of work (no shared
+    /// transaction was opened). Enabled only via
+    /// <see cref="AetherDomainEventOptions.DispatchNonTransactionalEventsToOutbox"/>.
+    /// <para>
+    /// The business data has already been durably persisted by the earlier (auto-save) writes, so
+    /// there is nothing to co-commit here: the events are dispatched with the configured
+    /// <see cref="AetherDomainEventOptions.DispatchStrategy"/> (writing outbox rows under
+    /// AlwaysUseOutbox) and any resulting rows are persisted by a final <see cref="SaveChangesAsync"/>.
+    /// Delivery is at-least-once but NOT atomic with the business writes — a crash between the two
+    /// relies on the consumer's idempotent retry/recovery.
+    /// </para>
+    /// </summary>
+    private async Task CommitWithoutTransactionAsync(CancellationToken cancellationToken)
+    {
+        await eventDispatcher!.DispatchEventsAsync(_events, cancellationToken);
+
+        // Persist any outbox rows written by the dispatcher. Without a shared transaction each
+        // SaveChanges auto-commits; a single outbox INSERT is atomic on its own.
+        await SaveChangesAsync(cancellationToken);
+
+        _events.Clear();
     }
 
     /// <summary>

--- a/framework/test/BBT.Aether.Postgres.Tests/NonTransactionalOutboxDispatchTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/NonTransactionalOutboxDispatchTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.EntityFrameworkCore;
+using BBT.Aether.Domain.EntityFrameworkCore.Modeling;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Events;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Persistence;
+using BBT.Aether.Uow;
+using BBT.Aether.Uow.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using OutboxMessage = BBT.Aether.Domain.Events.OutboxMessage;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Aether.Postgres.Tests;
+
+/// <summary>
+/// Validates <see cref="AetherDomainEventOptions.DispatchNonTransactionalEventsToOutbox"/>: when a
+/// unit of work runs WITHOUT a shared transaction (IsTransactional=false — the per-step / autoSave
+/// style used by long-running workflows), buffered domain events are normally dropped on commit
+/// because there is no transaction to co-commit them. The flag opts such flows into flushing their
+/// events to the outbox on commit (at-least-once, not atomic with the business writes).
+/// <para>
+/// Mirrors <see cref="OutboxWithinSharedTransactionTests"/>'s harness: a real
+/// <see cref="DomainEventDispatchStrategy.AlwaysUseOutbox"/> pipeline with a real outbox store; only
+/// the broker leg is stubbed.
+/// </para>
+/// </summary>
+[Collection("postgres")]
+public sealed class NonTransactionalOutboxDispatchTests(PostgresFixture fx)
+{
+    private readonly string _schema = "flow_ntx_" + Guid.NewGuid().ToString("N");
+
+    [EventName("OrderCreated", version: 1)]
+    private sealed class OrderCreatedEvent(Guid orderId) : IDistributedEvent
+    {
+        public Guid OrderId { get; } = orderId;
+    }
+
+    private sealed class Order : AggregateRoot<Guid>
+    {
+        private Order() { }
+
+        public Order(Guid id, string customer) : base(id)
+        {
+            Customer = customer;
+            AddDistributedEvent(new OrderCreatedEvent(id));
+        }
+
+        public string Customer { get; private set; } = string.Empty;
+    }
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options)
+        : AetherDbContext<TestDbContext>(options), IHasEfCoreOutbox
+    {
+        public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Order>(e =>
+            {
+                e.ToTable("orders");
+                e.HasKey(o => o.Id);
+                e.Property(o => o.Customer).IsRequired();
+            });
+            modelBuilder.ConfigureOutbox();
+        }
+    }
+
+    private sealed class NoopEventBus(
+        ITopicNameStrategy topicNameStrategy,
+        IEventSerializer eventSerializer,
+        IOutboxStore outboxStore,
+        AetherEventBusOptions eventBusOptions,
+        ICurrentSchema currentSchema)
+        : DistributedEventBusBase(topicNameStrategy, eventSerializer, outboxStore, eventBusOptions, currentSchema)
+    {
+        protected override Task PublishToBrokerAsync<TEvent>(string topic, byte[] serializedEnvelope, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        protected override Task PublishToBrokerAsync(string topic, string pubSubName, byte[] serializedEnvelope, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class SimpleTopicNameStrategy : ITopicNameStrategy
+    {
+        public string GetTopicName(Type eventType)
+        {
+            var info = EventNameAttribute.GetEventNameInfo(eventType);
+            return $"{info.EventName}.v{info.Version}";
+        }
+    }
+
+    private IServiceProvider BuildProvider(bool dispatchNonTransactional)
+    {
+        var services = new ServiceCollection();
+
+        services.AddAetherCore(_ => { });
+        // Session search-path mode so a non-transactional UoW is usable (TransactionLocal, the
+        // default, requires a transaction). This mirrors a deployment that runs non-transactional,
+        // per-step/autoSave transitions — exactly the flows the new flag targets.
+        services.AddAetherNpgsql<TestDbContext>(fx.ConnectionString, SchemaSwitchingMode.SessionSearchPath);
+        services.AddAetherDomainEvents<TestDbContext>(o =>
+            o.DispatchNonTransactionalEventsToOutbox = dispatchNonTransactional);
+        services.AddAetherOutbox<TestDbContext>();
+
+        services.AddSingleton(new AetherEventBusOptions { DefaultSource = "urn:test:orders" });
+        services.AddSingleton<ITopicNameStrategy, SimpleTopicNameStrategy>();
+        services.AddSingleton<IEventSerializer, SystemTextJsonEventSerializer>();
+        services.AddScoped<IDistributedEventBus, NoopEventBus>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private async Task ArrangeSchemaAsync(IServiceProvider sp)
+    {
+        await using (var conn = new NpgsqlConnection(fx.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"CREATE SCHEMA \"{_schema}\";";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var configurator = sp.GetRequiredService<
+            BBT.Aether.Uow.EntityFrameworkCore.IAetherDbContextConfigurator<TestDbContext>>();
+        await using var modelConn = new NpgsqlConnection(fx.ConnectionString);
+        await modelConn.OpenAsync();
+        await using var ctx = ActivatorUtilities.CreateInstance<TestDbContext>(
+            sp, configurator.BuildOptions(modelConn, _schema, new BBT.Aether.Uow.EntityFrameworkCore.SchemaScopeState()));
+        var script = ctx.Database.GenerateCreateScript();
+
+        await using var ddlConn = new NpgsqlConnection(fx.ConnectionString);
+        await ddlConn.OpenAsync();
+        await using (var setCmd = ddlConn.CreateCommand())
+        {
+            setCmd.CommandText = $"SET search_path TO \"{_schema}\";";
+            await setCmd.ExecuteNonQueryAsync();
+        }
+        await using (var ddlCmd = ddlConn.CreateCommand())
+        {
+            ddlCmd.CommandText = script;
+            await ddlCmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task<long> CountAsync(string table)
+    {
+        await using var conn = new NpgsqlConnection(fx.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM \"{_schema}\".\"{table}\"";
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    private async Task RunNonTransactionalAsync(IServiceProvider sp)
+    {
+        await using var scope = sp.CreateAsyncScope();
+        var ssp = scope.ServiceProvider;
+        var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+        var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+        var provider = ssp.GetRequiredService<IAetherDbContextProvider<TestDbContext>>();
+
+        using (currentSchema.Change(_schema))
+        {
+            // No transaction: the per-step / autoSave style. Business data is auto-committed by
+            // SaveChanges; there is no shared transaction to co-commit events with.
+            await using var uow = uowManager.Begin(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = false });
+
+            var ctx = await provider.GetDbContextAsync();
+            ctx.Set<Order>().Add(new Order(Guid.NewGuid(), "Alice"));
+
+            // Persist business data (and let the sink buffer the aggregate's event).
+            await uow.SaveChangesAsync();
+
+            await uow.CommitAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Flag_On_NonTransactional_Commit_Writes_Event_To_Outbox()
+    {
+        var sp = BuildProvider(dispatchNonTransactional: true);
+        await ArrangeSchemaAsync(sp);
+
+        await RunNonTransactionalAsync(sp);
+
+        (await CountAsync("orders")).ShouldBe(1);
+        (await CountAsync("OutboxMessages")).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Flag_Off_NonTransactional_Commit_Drops_Event_Historical_Behavior()
+    {
+        var sp = BuildProvider(dispatchNonTransactional: false);
+        await ArrangeSchemaAsync(sp);
+
+        await RunNonTransactionalAsync(sp);
+
+        // Business data is committed, but without a transaction and with the flag off the buffered
+        // event is not dispatched — the historical behavior the flag preserves by default.
+        (await CountAsync("orders")).ShouldBe(1);
+        (await CountAsync("OutboxMessages")).ShouldBe(0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for dispatching buffered domain events to the outbox when a non-transactional unit of work commits. This enables at-least-once event delivery for long-running workflows that use per-step `autoSave` persistence instead of a shared database transaction.

## Changes

- **AetherDomainEventOptions**: Added `DispatchNonTransactionalEventsToOutbox` boolean flag (default `false`) to opt-in to the new behavior. When enabled, non-transactional UoWs will flush their buffered events on commit using the configured `DispatchStrategy`.

- **CompositeUnitOfWork.CommitAsync**: Added conditional logic to detect non-transactional commits with buffered events and the flag enabled, routing to a new `CommitWithoutTransactionAsync` method.

- **CompositeUnitOfWork.CommitWithoutTransactionAsync**: New private method that dispatches buffered events (which writes outbox rows under `AlwaysUseOutbox` strategy) and persists them via a final `SaveChangesAsync`. Delivery is at-least-once but NOT atomic with the business writes—relies on consumer idempotency for crash recovery between the two durable writes.

- **NonTransactionalOutboxDispatchTests**: New comprehensive test suite validating the feature with a real outbox store and stubbed event broker. Tests confirm:
  - With flag enabled: events are written to outbox on non-transactional commit
  - With flag disabled: events are dropped (historical behavior preserved)

## Implementation Details

- The business data is already durably persisted by earlier per-step `SaveChanges` calls in the non-transactional flow, so there is no co-commit requirement—only the event dispatch and outbox persistence remain.
- The flag is config-gated to allow disabling at deploy time without code changes if production issues arise.
- Uses `SessionSearchPath` schema switching mode in tests to support non-transactional UoWs (the default `TransactionLocal` mode requires an active transaction).

## Summary by Sourcery

Enable optional dispatch of buffered domain events to the outbox when committing non-transactional units of work.

New Features:
- Introduce configuration flag to allow non-transactional units of work to flush buffered domain events to the outbox on commit.

Enhancements:
- Extend composite unit of work commit flow with a non-transactional commit path that dispatches buffered events and persists resulting outbox entries.

Tests:
- Add end-to-end Postgres test suite verifying outbox behavior for non-transactional units of work with the feature flag enabled and disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to dispatch domain events from non-transactional operations to the outbox.
  * When enabled, events are persisted for at-least-once delivery after the operation commits.
  * Existing behavior remains unchanged when the option is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->