### PR TITLE
v1.0.30

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -155,7 +155,7 @@ jobs:
           "./framework/src/BBT.Aether.Abstractions/BBT.Aether.Abstractions.csproj"
           "./framework/src/BBT.Aether.Aspects/BBT.Aether.Aspects.csproj"
           "./framework/src/BBT.Aether.AutoMapper/BBT.Aether.AutoMapper.csproj"
-          "./framework/src/BBT.Aether.Mapperly/BBT.Aether.Mapperly.csproj",
+          "./framework/src/BBT.Aether.Mapperly/BBT.Aether.Mapperly.csproj"
           "./framework/src/BBT.Aether.Npgsql/BBT.Aether.Npgsql.csproj"
         )
         

--- a/framework/src/BBT.Aether.Core/BBT/Aether/Events/AetherDomainEventOptions.cs
+++ b/framework/src/BBT.Aether.Core/BBT/Aether/Events/AetherDomainEventOptions.cs
@@ -30,5 +30,27 @@ public class AetherDomainEventOptions
     /// Default is AlwaysUseOutbox for maximum reliability.
     /// </summary>
     public DomainEventDispatchStrategy DispatchStrategy { get; set; } = DomainEventDispatchStrategy.AlwaysUseOutbox;
+
+    /// <summary>
+    /// Gets or sets whether a non-transactional unit of work (one with no shared database
+    /// transaction — e.g. a flow that persists via per-step <c>autoSave</c> rather than a single
+    /// enclosing transaction) also flushes its buffered domain events when it commits.
+    /// <para>
+    /// Default is <see langword="false"/> — the historical behavior: without a transaction the
+    /// unit of work cannot co-commit events atomically with the business data, so buffered events
+    /// are NOT dispatched and are effectively dropped. Callers that need events in such flows have
+    /// to publish them explicitly.
+    /// </para>
+    /// <para>
+    /// When set to <see langword="true"/>, on commit the unit of work dispatches its buffered
+    /// events using the configured <see cref="DispatchStrategy"/> even though no transaction was
+    /// opened. The business data has already been durably written by the per-step saves, so this
+    /// restores at-least-once delivery for these flows; it is NOT atomic with the business writes
+    /// (the event write is a separate durable write), so a crash between the two relies on the
+    /// consumer's idempotent retry/recovery. This is config-gated precisely so it can be disabled
+    /// at deploy time — without a code change — if it causes issues in production.
+    /// </para>
+    /// </summary>
+    public bool DispatchNonTransactionalEventsToOutbox { get; set; }
 }
 

--- a/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Uow/CompositeUnitOfWork.cs
+++ b/framework/src/BBT.Aether.Infrastructure/BBT/Aether/Uow/CompositeUnitOfWork.cs
@@ -239,6 +239,12 @@ public sealed class CompositeUnitOfWork(
                     await CommitWithDirectPublishAsync(cancellationToken);
                 }
             }
+            else if ((domainEventOptions?.DispatchNonTransactionalEventsToOutbox ?? false)
+                     && _events.Count > 0
+                     && eventDispatcher is not null)
+            {
+                await CommitWithoutTransactionAsync(cancellationToken);
+            }
 
             IsCompleted = true;
             await InvokeCompletedHandlersAsync();
@@ -267,6 +273,30 @@ public sealed class CompositeUnitOfWork(
         }
 
         await _transaction!.CommitAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Dispatches buffered domain events for a non-transactional unit of work (no shared
+    /// transaction was opened). Enabled only via
+    /// <see cref="AetherDomainEventOptions.DispatchNonTransactionalEventsToOutbox"/>.
+    /// <para>
+    /// The business data has already been durably persisted by the earlier (auto-save) writes, so
+    /// there is nothing to co-commit here: the events are dispatched with the configured
+    /// <see cref="AetherDomainEventOptions.DispatchStrategy"/> (writing outbox rows under
+    /// AlwaysUseOutbox) and any resulting rows are persisted by a final <see cref="SaveChangesAsync"/>.
+    /// Delivery is at-least-once but NOT atomic with the business writes — a crash between the two
+    /// relies on the consumer's idempotent retry/recovery.
+    /// </para>
+    /// </summary>
+    private async Task CommitWithoutTransactionAsync(CancellationToken cancellationToken)
+    {
+        await eventDispatcher!.DispatchEventsAsync(_events, cancellationToken);
+
+        // Persist any outbox rows written by the dispatcher. Without a shared transaction each
+        // SaveChanges auto-commits; a single outbox INSERT is atomic on its own.
+        await SaveChangesAsync(cancellationToken);
+
+        _events.Clear();
     }
 
     /// <summary>

--- a/framework/test/BBT.Aether.Postgres.Tests/NonTransactionalOutboxDispatchTests.cs
+++ b/framework/test/BBT.Aether.Postgres.Tests/NonTransactionalOutboxDispatchTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BBT.Aether.Domain.EntityFrameworkCore;
+using BBT.Aether.Domain.EntityFrameworkCore.Modeling;
+using BBT.Aether.Domain.Entities;
+using BBT.Aether.Events;
+using BBT.Aether.MultiSchema;
+using BBT.Aether.Persistence;
+using BBT.Aether.Uow;
+using BBT.Aether.Uow.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using OutboxMessage = BBT.Aether.Domain.Events.OutboxMessage;
+using Shouldly;
+using Xunit;
+
+namespace BBT.Aether.Postgres.Tests;
+
+/// <summary>
+/// Validates <see cref="AetherDomainEventOptions.DispatchNonTransactionalEventsToOutbox"/>: when a
+/// unit of work runs WITHOUT a shared transaction (IsTransactional=false — the per-step / autoSave
+/// style used by long-running workflows), buffered domain events are normally dropped on commit
+/// because there is no transaction to co-commit them. The flag opts such flows into flushing their
+/// events to the outbox on commit (at-least-once, not atomic with the business writes).
+/// <para>
+/// Mirrors <see cref="OutboxWithinSharedTransactionTests"/>'s harness: a real
+/// <see cref="DomainEventDispatchStrategy.AlwaysUseOutbox"/> pipeline with a real outbox store; only
+/// the broker leg is stubbed.
+/// </para>
+/// </summary>
+[Collection("postgres")]
+public sealed class NonTransactionalOutboxDispatchTests(PostgresFixture fx)
+{
+    private readonly string _schema = "flow_ntx_" + Guid.NewGuid().ToString("N");
+
+    [EventName("OrderCreated", version: 1)]
+    private sealed class OrderCreatedEvent(Guid orderId) : IDistributedEvent
+    {
+        public Guid OrderId { get; } = orderId;
+    }
+
+    private sealed class Order : AggregateRoot<Guid>
+    {
+        private Order() { }
+
+        public Order(Guid id, string customer) : base(id)
+        {
+            Customer = customer;
+            AddDistributedEvent(new OrderCreatedEvent(id));
+        }
+
+        public string Customer { get; private set; } = string.Empty;
+    }
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options)
+        : AetherDbContext<TestDbContext>(options), IHasEfCoreOutbox
+    {
+        public DbSet<OutboxMessage> OutboxMessages => Set<OutboxMessage>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Order>(e =>
+            {
+                e.ToTable("orders");
+                e.HasKey(o => o.Id);
+                e.Property(o => o.Customer).IsRequired();
+            });
+            modelBuilder.ConfigureOutbox();
+        }
+    }
+
+    private sealed class NoopEventBus(
+        ITopicNameStrategy topicNameStrategy,
+        IEventSerializer eventSerializer,
+        IOutboxStore outboxStore,
+        AetherEventBusOptions eventBusOptions,
+        ICurrentSchema currentSchema)
+        : DistributedEventBusBase(topicNameStrategy, eventSerializer, outboxStore, eventBusOptions, currentSchema)
+    {
+        protected override Task PublishToBrokerAsync<TEvent>(string topic, byte[] serializedEnvelope, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        protected override Task PublishToBrokerAsync(string topic, string pubSubName, byte[] serializedEnvelope, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class SimpleTopicNameStrategy : ITopicNameStrategy
+    {
+        public string GetTopicName(Type eventType)
+        {
+            var info = EventNameAttribute.GetEventNameInfo(eventType);
+            return $"{info.EventName}.v{info.Version}";
+        }
+    }
+
+    private IServiceProvider BuildProvider(bool dispatchNonTransactional)
+    {
+        var services = new ServiceCollection();
+
+        services.AddAetherCore(_ => { });
+        // Session search-path mode so a non-transactional UoW is usable (TransactionLocal, the
+        // default, requires a transaction). This mirrors a deployment that runs non-transactional,
+        // per-step/autoSave transitions — exactly the flows the new flag targets.
+        services.AddAetherNpgsql<TestDbContext>(fx.ConnectionString, SchemaSwitchingMode.SessionSearchPath);
+        services.AddAetherDomainEvents<TestDbContext>(o =>
+            o.DispatchNonTransactionalEventsToOutbox = dispatchNonTransactional);
+        services.AddAetherOutbox<TestDbContext>();
+
+        services.AddSingleton(new AetherEventBusOptions { DefaultSource = "urn:test:orders" });
+        services.AddSingleton<ITopicNameStrategy, SimpleTopicNameStrategy>();
+        services.AddSingleton<IEventSerializer, SystemTextJsonEventSerializer>();
+        services.AddScoped<IDistributedEventBus, NoopEventBus>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private async Task ArrangeSchemaAsync(IServiceProvider sp)
+    {
+        await using (var conn = new NpgsqlConnection(fx.ConnectionString))
+        {
+            await conn.OpenAsync();
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"CREATE SCHEMA \"{_schema}\";";
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        var configurator = sp.GetRequiredService<
+            BBT.Aether.Uow.EntityFrameworkCore.IAetherDbContextConfigurator<TestDbContext>>();
+        await using var modelConn = new NpgsqlConnection(fx.ConnectionString);
+        await modelConn.OpenAsync();
+        await using var ctx = ActivatorUtilities.CreateInstance<TestDbContext>(
+            sp, configurator.BuildOptions(modelConn, _schema, new BBT.Aether.Uow.EntityFrameworkCore.SchemaScopeState()));
+        var script = ctx.Database.GenerateCreateScript();
+
+        await using var ddlConn = new NpgsqlConnection(fx.ConnectionString);
+        await ddlConn.OpenAsync();
+        await using (var setCmd = ddlConn.CreateCommand())
+        {
+            setCmd.CommandText = $"SET search_path TO \"{_schema}\";";
+            await setCmd.ExecuteNonQueryAsync();
+        }
+        await using (var ddlCmd = ddlConn.CreateCommand())
+        {
+            ddlCmd.CommandText = script;
+            await ddlCmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task<long> CountAsync(string table)
+    {
+        await using var conn = new NpgsqlConnection(fx.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"SELECT COUNT(*) FROM \"{_schema}\".\"{table}\"";
+        return (long)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    private async Task RunNonTransactionalAsync(IServiceProvider sp)
+    {
+        await using var scope = sp.CreateAsyncScope();
+        var ssp = scope.ServiceProvider;
+        var currentSchema = ssp.GetRequiredService<ICurrentSchema>();
+        var uowManager = ssp.GetRequiredService<IUnitOfWorkManager>();
+        var provider = ssp.GetRequiredService<IAetherDbContextProvider<TestDbContext>>();
+
+        using (currentSchema.Change(_schema))
+        {
+            // No transaction: the per-step / autoSave style. Business data is auto-committed by
+            // SaveChanges; there is no shared transaction to co-commit events with.
+            await using var uow = uowManager.Begin(
+                new UnitOfWorkOptions { Scope = UnitOfWorkScopeOption.RequiresNew, IsTransactional = false });
+
+            var ctx = await provider.GetDbContextAsync();
+            ctx.Set<Order>().Add(new Order(Guid.NewGuid(), "Alice"));
+
+            // Persist business data (and let the sink buffer the aggregate's event).
+            await uow.SaveChangesAsync();
+
+            await uow.CommitAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Flag_On_NonTransactional_Commit_Writes_Event_To_Outbox()
+    {
+        var sp = BuildProvider(dispatchNonTransactional: true);
+        await ArrangeSchemaAsync(sp);
+
+        await RunNonTransactionalAsync(sp);
+
+        (await CountAsync("orders")).ShouldBe(1);
+        (await CountAsync("OutboxMessages")).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Flag_Off_NonTransactional_Commit_Drops_Event_Historical_Behavior()
+    {
+        var sp = BuildProvider(dispatchNonTransactional: false);
+        await ArrangeSchemaAsync(sp);
+
+        await RunNonTransactionalAsync(sp);
+
+        // Business data is committed, but without a transaction and with the flag off the buffered
+        // event is not dispatched — the historical behavior the flag preserves by default.
+        (await CountAsync("orders")).ShouldBe(1);
+        (await CountAsync("OutboxMessages")).ShouldBe(0);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add configurable support for dispatching buffered domain events from non-transactional units of work to the outbox on commit, and validate the behavior with new PostgreSQL integration tests.

New Features:
- Introduce the DispatchNonTransactionalEventsToOutbox option to allow non-transactional units of work to flush buffered domain events using the configured dispatch strategy.
- Add non-transactional commit handling in CompositeUnitOfWork that dispatches domain events and persists outbox messages even when no shared transaction is opened.

Enhancements:
- Tighten documentation on domain event dispatch behavior for non-transactional flows in infrastructure options and unit-of-work comments.

Build:
- Fix a syntax issue in the publish-nuget GitHub workflow project list.

Tests:
- Add NonTransactionalOutboxDispatchTests to verify that enabling DispatchNonTransactionalEventsToOutbox writes events to the outbox, and that disabling it preserves the historical behavior of dropping events for non-transactional commits.