### PR TITLE
feat(telemetry): make enricher header key prefix configurable

### DIFF
--- a/framework/docs/telemetry/README.md
+++ b/framework/docs/telemetry/README.md
@@ -92,7 +92,9 @@ Config section key: `Telemetry` or `Aether:Telemetry`.
       "ParseStateValues": true,
       "Enrichers": {
         "CustomAttributes": { "env": "Production", "team": "platform" },
-        "Headers": ["x-correlation-id", "x-request-id"]
+        "Headers": ["x-correlation-id", "x-request-id"],
+        "RequestHeaderKeyPrefix": "RequestHeader.",
+        "ResponseHeaderKeyPrefix": "ResponseHeader."
       },
       "Body": {
         "EnableRequestBody": false,
@@ -278,7 +280,8 @@ public class OrderMetrics
 `Telemetry:Logging:Enrichers` (CustomAttributes and Headers) are added as attributes to **every** log record in the application via `EnricherLogProcessor`. This allows querying all logs with the same enrich fields (e.g. `env`, `app`, `RequestHeader.x_correlation_id`) in a single observability query.
 
 - **CustomAttributes**: Key-value pairs added to every log.
-- **Headers**: Listed request/response headers are added as `RequestHeader.<name>` and `ResponseHeader.<name>`; values for headers in the sensitive list are redacted. When there is no HTTP context (e.g. background job), only CustomAttributes are added.
+- **Headers**: Listed request/response headers are added as `RequestHeader.<name>` and `ResponseHeader.<name>`; values for headers in the sensitive list are redacted. When there is no HTTP context (e.g. background job), only CustomAttributes are added. The header name is normalized (lowercased, `-` replaced by `_`), so `X-Request-Id` becomes `RequestHeader.x_request_id`.
+- **RequestHeaderKeyPrefix / ResponseHeaderKeyPrefix**: The prefixes above are configurable (defaults `RequestHeader.` / `ResponseHeader.`). Log backends that cannot store dots in flat field names — OpenObserve, Elasticsearch — lowercase the key and replace `.` with `_` on ingest, so `RequestHeader.act_sub` is queried as `requestheader_act_sub`. Set the prefix to `""` to emit the bare header name (`act_sub`) instead. Request and response keys are distinguished only by these prefixes: giving both the same value (for example both empty) makes a header present on both request and response collapse onto a single key.
 
 ### Automatic Enrichment
 

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/EnricherLogProcessor.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/EnricherLogProcessor.cs
@@ -38,15 +38,16 @@ public sealed class EnricherLogProcessor(
         }
 
         var httpContext = httpContextAccessor?.HttpContext;
-        if (httpContext != null && options.Logging?.Enrichers?.Headers is { Count: > 0 } headerNames)
+        if (httpContext != null && options.Logging?.Enrichers is { } enrichers
+            && enrichers.Headers is { Count: > 0 } headerNames)
         {
             foreach (var headerName in headerNames)
             {
                 if (string.IsNullOrWhiteSpace(headerName))
                     continue;
                 var key = headerName.Trim();
-                var requestKey = $"RequestHeader.{NormalizeHeaderKey(key)}";
-                var responseKey = $"ResponseHeader.{NormalizeHeaderKey(key)}";
+                var requestKey = HeaderEnrichmentKeys.Request(enrichers, key);
+                var responseKey = HeaderEnrichmentKeys.Response(enrichers, key);
                 var isSensitive = _sensitiveHeaderNames.Contains(key);
 
                 if (httpContext.Request.Headers.TryGetValue(key, out var reqVal))
@@ -89,7 +90,4 @@ public sealed class EnricherLogProcessor(
         }
         return false;
     }
-
-    private static string NormalizeHeaderKey(string key)
-        => key.Replace("-", "_", StringComparison.Ordinal).ToLowerInvariant();
 }

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/HeaderEnrichmentKeys.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/HeaderEnrichmentKeys.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace BBT.Aether.AspNetCore.Telemetry;
+
+/// <summary>
+/// Builds the attribute keys used to enrich log records with individual HTTP header values.
+/// Shared by <see cref="EnricherLogProcessor"/> (all log records) and
+/// <see cref="HttpBodyLoggingMiddleware"/> (the HTTP body log scope) so the two paths cannot
+/// drift apart and both honour the configured prefixes.
+/// </summary>
+internal static class HeaderEnrichmentKeys
+{
+    /// <summary>
+    /// Normalizes a header name for use in an attribute key: lowercase, with '-' replaced by '_'
+    /// (e.g. <c>X-Request-Id</c> becomes <c>x_request_id</c>).
+    /// </summary>
+    internal static string Normalize(string headerName)
+        => headerName.Replace("-", "_", StringComparison.Ordinal).ToLowerInvariant();
+
+    /// <summary>
+    /// Builds the enrich key for a header read from the request, honouring
+    /// <see cref="LoggingEnricherOptions.RequestHeaderKeyPrefix"/>.
+    /// </summary>
+    internal static string Request(LoggingEnricherOptions options, string headerName)
+        => $"{options.RequestHeaderKeyPrefix ?? string.Empty}{Normalize(headerName)}";
+
+    /// <summary>
+    /// Builds the enrich key for a header read from the response, honouring
+    /// <see cref="LoggingEnricherOptions.ResponseHeaderKeyPrefix"/>.
+    /// </summary>
+    internal static string Response(LoggingEnricherOptions options, string headerName)
+        => $"{options.ResponseHeaderKeyPrefix ?? string.Empty}{Normalize(headerName)}";
+}

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/HttpBodyLoggingMiddleware.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/HttpBodyLoggingMiddleware.cs
@@ -346,8 +346,8 @@ public sealed class HttpBodyLoggingMiddleware
             if (string.IsNullOrWhiteSpace(headerName))
                 continue;
             var key = headerName.Trim();
-            var requestKey = $"RequestHeader.{key.Replace("-", "_", StringComparison.Ordinal).ToLowerInvariant()}";
-            var responseKey = $"ResponseHeader.{key.Replace("-", "_", StringComparison.Ordinal).ToLowerInvariant()}";
+            var requestKey = HeaderEnrichmentKeys.Request(_enricherOptions, key);
+            var responseKey = HeaderEnrichmentKeys.Response(_enricherOptions, key);
             var isSensitive = _sensitiveHeaderNames.Contains(key);
 
             if (context.Request.Headers.TryGetValue(key, out var reqVal))

--- a/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/TelemetryOptions.cs
+++ b/framework/src/BBT.Aether.AspNetCore/BBT/Aether/AspNetCore/Telemetry/TelemetryOptions.cs
@@ -110,6 +110,29 @@ public sealed class LoggingEnricherOptions
     /// Header names to add as individual enrich properties (e.g. RequestHeader.x_correlation_id). Values for headers in the sensitive list are shown as ***REDACTED***. Full request/response headers remain in RequestHeaders/ResponseHeaders JSON.
     /// </summary>
     public List<string> Headers { get; set; } = new();
+
+    /// <summary>
+    /// Prefix applied to request-header enrich keys. Defaults to <c>"RequestHeader."</c>, so the
+    /// header <c>x-correlation-id</c> is emitted as <c>RequestHeader.x_correlation_id</c>.
+    /// <para>
+    /// Set to an empty string to emit the bare (normalized) header name instead — useful for log
+    /// backends such as OpenObserve or Elasticsearch, which cannot store dots in flat field names
+    /// and therefore lowercase the key and replace <c>.</c> with <c>_</c> on ingest, turning
+    /// <c>RequestHeader.act_sub</c> into <c>requestheader_act_sub</c>.
+    /// </para>
+    /// <para>
+    /// Note: request and response keys are distinguished only by these prefixes. Setting this and
+    /// <see cref="ResponseHeaderKeyPrefix"/> to the same value (for example both empty) makes a
+    /// header present on both the request and the response collapse onto a single key.
+    /// </para>
+    /// </summary>
+    public string RequestHeaderKeyPrefix { get; set; } = "RequestHeader.";
+
+    /// <summary>
+    /// Prefix applied to response-header enrich keys. Defaults to <c>"ResponseHeader."</c>.
+    /// See <see cref="RequestHeaderKeyPrefix"/> for the prefix semantics and the collision note.
+    /// </summary>
+    public string ResponseHeaderKeyPrefix { get; set; } = "ResponseHeader.";
 }
 
 public sealed class AetherTracingOptions


### PR DESCRIPTION
## Problem

Header enrich keys are built from hard-coded `"RequestHeader."` / `"ResponseHeader."` literals, so consumers cannot control the resulting field name.

This matters because log backends that cannot store dots in flat field names — OpenObserve, Elasticsearch — lowercase the key and replace `.` with `_` on ingest. An application that enriches on the header `act_sub` therefore has to query it as:

```
act_sub  (appsettings)
  -> RequestHeader.act_sub      (Aether attribute key, EnricherLogProcessor.cs)
  -> requestheader_act_sub      (backend field name)
```

The prefix ends up baked into the queried field name with no way to opt out. The same two literals are also duplicated in `HttpBodyLoggingMiddleware`, together with a copy of the `-` → `_` + lowercase normalization expression, so the two enrichment paths can silently drift apart.

## Change

- **`LoggingEnricherOptions`**: new `RequestHeaderKeyPrefix` / `ResponseHeaderKeyPrefix`, defaulting to `"RequestHeader."` / `"ResponseHeader."`. Setting a prefix to `""` emits the bare normalized header name (`act_sub`).
- **New internal `HeaderEnrichmentKeys`**: centralizes key construction and header-name normalization. `EnricherLogProcessor` and `HttpBodyLoggingMiddleware` both use it instead of duplicating the literals and the normalize expression.
- **`docs/telemetry`**: documents the new options, the backend field-name normalization that motivates them, and the caveat that request and response keys are distinguished only by these prefixes — giving both the same value (for example both empty) makes a header present on both request and response collapse onto a single key.

## Compatibility

Defaults preserve the current behaviour exactly; no change for existing consumers. Only `BBT.Aether.AspNetCore` is affected.

## Verification

`dotnet build framework/BBT.Aether.slnx` → 0 errors. There is no test project for `BBT.Aether.AspNetCore` in `framework/test` (only Infrastructure / Postgres / SqlServer), so the change is verified by build plus review that the defaults are byte-identical to the previous literals.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEhpuhoutHd7Bk15HJiHEm)_

## Summary by Sourcery

Make HTTP header enrichment keys configurable and unify their construction across telemetry components.

New Features:
- Add configurable request and response header key prefixes to logging enricher options so consumers can control enriched header field names.

Enhancements:
- Introduce a shared helper for normalizing header names and building enrichment keys, ensuring consistent behavior between log processor and HTTP body logging middleware.

Documentation:
- Update telemetry documentation to describe header key prefix options, header name normalization, and the implications of configuring identical prefixes for request and response headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable prefixes for request and response header fields in telemetry logs.
  * Request headers default to `RequestHeader.` and response headers to `ResponseHeader.`.
  * Header names are normalized consistently across telemetry output.

* **Documentation**
  * Documented custom prefixes, empty-prefix behavior, backend-specific transformations, and potential naming collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->