### PR TITLE
ci(nuget): switch publishing to NuGet.org Trusted Publishing

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write  # NuGet.org Trusted Publishing (OIDC) için gerekli
 
 jobs:
   build-and-publish:
@@ -214,18 +215,32 @@ jobs:
         path: packages/
         retention-days: 30
     
+    # Trusted Publishing: GitHub'ın OIDC token'ı NuGet.org'a gönderilir ve
+    # 1 saat geçerli, tek kullanımlık kısa ömürlü bir API key alınır.
+    # Anahtar kısa ömürlü olduğu için bu adım push'tan hemen önce çalışmalıdır.
+    # NuGet.org policy'si bu workflow dosya adına (publish-nuget.yml) bağlıdır;
+    # dosyayı yeniden adlandırırsanız policy'yi de güncellemek gerekir.
+    - name: NuGet login (OIDC → short-lived API key)
+      id: nuget-login
+      uses: NuGet/login@v1
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish to NuGet.org
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
-        # Check if API key is configured
+        # Verify the OIDC token exchange produced a key
         if [ -z "$NUGET_API_KEY" ]; then
-          echo "❌ Error: NUGET_API_KEY secret is not configured"
-          echo "Please add your NuGet.org API key as a repository secret named 'NUGET_API_KEY'"
-          echo "Get your API key from: https://www.nuget.org/account/apikeys"
+          echo "❌ Error: Trusted Publishing did not return an API key"
+          echo "Checklist:"
+          echo "  - NUGET_USER secret must be your nuget.org profile name (not e-mail)"
+          echo "  - nuget.org Trusted Publishing policy must match:"
+          echo "      owner=${{ github.repository_owner }}, repo=${{ github.event.repository.name }}, workflow=publish-nuget.yml"
+          echo "  - Job must have 'id-token: write' permission"
           exit 1
         fi
-        
+
         echo "🚀 Publishing packages to NuGet.org..."
         
         FORCE_FLAG=""


### PR DESCRIPTION
## What changed

`publish-nuget.yml` now authenticates to NuGet.org via **Trusted Publishing** (OIDC) instead of a long-lived API key secret.

- Added `id-token: write` to the workflow `permissions` so GitHub can issue an OIDC token.
- Added a `NuGet/login@v1` step that exchanges that token for a short-lived nuget.org API key.
- The push step now reads `steps.nuget-login.outputs.NUGET_API_KEY` instead of `secrets.NUGET_API_KEY`.
- The old "API key secret is not configured" guard was replaced with a checklist that surfaces the likely policy/permission mismatch if the token exchange returns nothing.

## Why

No durable publishing credential is stored in GitHub anymore, so there is nothing to rotate and nothing to leak. This follows [the NuGet Trusted Publishing docs](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).

## Reviewer notes

- **Placement is deliberate**: the temporary key is valid for **1 hour** and is **single-use**, so the login step sits immediately before the push — after build, test, pack, and artifact upload — rather than at the top of the job.
- **The nuget.org policy is bound to this file's name.** Renaming `publish-nuget.yml` will break publishing until the policy is updated. The policy's *Workflow File* field must be exactly `publish-nuget.yml`, with no `.github/workflows/` prefix.
- This workflow uses no `environment:`, so the policy's *Environment* field must be left empty.

## Required before the next release

- [ ] Add a `NUGET_USER` repository secret containing the nuget.org **profile name** (not the e-mail address). This is the value `NuGet/login` sends during the token exchange; the docs recommend a secret over hardcoding.
- [ ] The Trusted Publishing policy on nuget.org already exists (added by @tayfunyilmaz-burgantech). Verify owner/repo/workflow match `burgan-tech` / `aether` / `publish-nuget.yml`.
- [ ] After the first successful publish, the now-unused `NUGET_API_KEY` secret can be deleted. No other reference to it remains in the repo.

For private repositories a new policy starts *temporarily active* for 7 days and goes inactive if no publish happens in that window, so the first release should run within a week of the policy being created.

## Testing

Not exercised end-to-end — this workflow only runs on `release-v*` branches, so the OIDC exchange is first verified by the next real release run. The `NUGET_USER` secret must be in place before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch NuGet publishing workflow to use NuGet.org Trusted Publishing via OIDC-issued short-lived API keys instead of a stored API key secret.

CI:
- Update publish-nuget GitHub Actions workflow permissions to allow OIDC token issuance for NuGet Trusted Publishing.
- Integrate NuGet/login action to obtain a short-lived NuGet.org API key immediately before package push and wire the publish step to use its output.
- Replace the previous missing-secret guard with an error checklist tailored to Trusted Publishing configuration (NUGET_USER, policy matching, id-token permission).